### PR TITLE
Update to the latest LTS: 5.15.45

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-5.15.44
+KERNEL_VERSION = linux-5.15.45
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v5.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
@@ -6,7 +6,7 @@ KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)
 KERNEL_C_BUNDLE = kernel.c
 
 ABI_VERSION=2
-FULL_VERSION=2.1.1
+FULL_VERSION=2.1.2
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,4 +1,4 @@
-From f1df8200225c7b705bbae89a9ef5140c44843d18 Mon Sep 17 00:00:00 2001
+From f608095cb2f9465f8ac5ae5dce65cfe74e6abdd6 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
 Subject: [PATCH 12/13] virtio: enable DMA API if memory is restricted

--- a/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
+++ b/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
@@ -1,4 +1,4 @@
-From 3f966f0b658e68989ddd9b9d986fc3ca8c0e3c8c Mon Sep 17 00:00:00 2001
+From 6f75026ea709579a03b4038ab50b9365fc04e15e Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 24 Sep 2021 17:50:39 +0200
 Subject: [PATCH 13/13] Allow booting SEV-ES APs without GHCB (HACK)

--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,7 +1,7 @@
-From d300a869e21233f3d2706f31065b9139f9d0c9e1 Mon Sep 17 00:00:00 2001
+From 425d8b110b21bd1cfd8499a06f44dec20071bf86 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 15:47:50 +0200
-Subject: [PATCH 01/11] krunfw: Don't panic when init dies
+Subject: [PATCH 01/13] krunfw: Don't panic when init dies
 
 In libkrun, the isolated process runs as PID 1. When it exits,
 trigger an orderly reboot instead of panic'ing.

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,7 +1,7 @@
-From fcdb9233d416896492c62ee075e220e2ebdee96d Mon Sep 17 00:00:00 2001
+From b8e254bdd253d141203000c64caf920c98c2a9fd Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
-Subject: [PATCH 02/11] krunfw: Ignore run_cmd on orderly reboot
+Subject: [PATCH 02/13] krunfw: Ignore run_cmd on orderly reboot
 
 We don't really support restarting the conventional way, so ignore
 "run_cmd" so we can fall back to an emergency sync and reboot.

--- a/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,7 +1,7 @@
-From f16ed04df0389ea3de0d1d3710c39a1115a4fe58 Mon Sep 17 00:00:00 2001
+From fa83e491f26b519b328abce24ee91e06d05ec1e3 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Tue, 6 Apr 2021 23:22:06 +0000
-Subject: [PATCH 03/11] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
+Subject: [PATCH 03/13] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
 
 When this feature is enabled, allocate 5 queues,
 otherwise, allocate 3 queues to be compatible with

--- a/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
+++ b/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
@@ -1,7 +1,7 @@
-From 90639292120c5375fa9edfe725f248c1aa0ffe1d Mon Sep 17 00:00:00 2001
+From 22dd1fdaed61c1ed3b31c89eb941526ff8862cff Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:43:37 +0200
-Subject: [PATCH 04/11] virtio/vsock: add support for virtio datagram
+Subject: [PATCH 04/13] virtio/vsock: add support for virtio datagram
 
 This patch add support for virtio dgram for the driver.
 Implemented related functions for tx and rx, enqueue

--- a/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
+++ b/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
@@ -1,7 +1,7 @@
-From 89ffacad66e47c7a85d953c3f5e608c1e4f94f5d Mon Sep 17 00:00:00 2001
+From e535eda51049943e5d686c0941cd84a08171e367 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 10 Dec 2021 12:42:16 +0100
-Subject: [PATCH 05/11] vhost/vsock: add support for vhost dgram.
+Subject: [PATCH 05/13] vhost/vsock: add support for vhost dgram.
 
 This patch supports dgram on vhost side, including
 tx and rx. The vhost send packets asynchronously.

--- a/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
+++ b/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
@@ -1,7 +1,7 @@
-From d4e48fed0a031fb11181fb454989a5ab3412e758 Mon Sep 17 00:00:00 2001
+From 9b0266c0c65d5edfe34c9abc4db6abafdfcfdc03 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 9 Apr 2021 18:32:20 +0000
-Subject: [PATCH 06/11] vsock_test: add tests for vsock dgram
+Subject: [PATCH 06/13] vsock_test: add tests for vsock dgram
 
 Added test cases for vsock dgram types.
 

--- a/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
+++ b/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
@@ -1,7 +1,7 @@
-From b489a8f7a58c60315d5c7b64c7f8230d69927879 Mon Sep 17 00:00:00 2001
+From a88472c56679008eb33d4ce53b460579131976f9 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:46:09 +0200
-Subject: [PATCH 07/11] virtio/vsock: add sysfs for rx buf len for dgram
+Subject: [PATCH 07/13] virtio/vsock: add sysfs for rx buf len for dgram
 
 Make rx buf len configurable via sysfs
 

--- a/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
+++ b/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
@@ -1,7 +1,7 @@
-From 53be0f8ae1474cfab23ef97fd1c9d18ab1a0e8df Mon Sep 17 00:00:00 2001
+From 041d4cf74bf2da4e3dab348274efe632a91ebafb Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:31:03 +0200
-Subject: [PATCH 08/11] virtio/vsock: Fix DGRAM polling
+Subject: [PATCH 08/13] virtio/vsock: Fix DGRAM polling
 
 Fix DGRAM polling.
 

--- a/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
+++ b/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
@@ -1,7 +1,7 @@
-From 599f4dbb789ae536b6764d0fac1f8abfcb9fe679 Mon Sep 17 00:00:00 2001
+From 10c4d2832204831b719bc3e6430e87b86fc5b169 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:34:49 +0200
-Subject: [PATCH 09/11] virtio/vsock: add DGRAM to virtio_transport_get_type
+Subject: [PATCH 09/13] virtio/vsock: add DGRAM to virtio_transport_get_type
 
 Add missing DGRAM to virtio_transport_get_type.
 

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -1,7 +1,7 @@
-From 433448a2633a7aa13a10e087022fcc0f4c2cd352 Mon Sep 17 00:00:00 2001
+From deb3aec5634ec49e81d771a5ed1cc0d89c1bf6f0 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
-Subject: [PATCH 10/11] Transparent Socket Impersonation implementation
+Subject: [PATCH 10/13] Transparent Socket Impersonation implementation
 
 Transparent Socket Impersonation (AF_TSI) is an address family that
 provides sockets presenting two simultaneous personalities, AF_INET

--- a/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,7 +1,7 @@
-From 44d3828f38659961d43c308a0a163196cb164f95 Mon Sep 17 00:00:00 2001
+From 94a44060014a6a4b4a865e9651a6e804a4293a7c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
-Subject: [PATCH 11/11] tsi: allow hijacking sockets (tsi_hijack)
+Subject: [PATCH 11/13] tsi: allow hijacking sockets (tsi_hijack)
 
 Add a kernel command line option (tsi_hijack) enabling users to
 request the kernel to hijack AF_INET(SOCK_STREAM || SOCK_DGRAM)


### PR DESCRIPTION
Update to the latest available LTS, 5.15.45. The patches still apply
cleanly, no need to update them.

Signed-off-by: Sergio Lopez <slp@redhat.com>