### PR TITLE
Rebase kernel on v5.15.52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-5.15.47
+KERNEL_VERSION = linux-5.15.52
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v5.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
@@ -6,7 +6,7 @@ KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)
 KERNEL_C_BUNDLE = kernel.c
 
 ABI_VERSION=3
-FULL_VERSION=3.0.0
+FULL_VERSION=3.1.0
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,4 +1,4 @@
-From 013aa017f53073261ff9d504e335a45910043971 Mon Sep 17 00:00:00 2001
+From 85faae5803d4aad873e04761a108cb91763edf19 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
 Subject: [PATCH 12/13] virtio: enable DMA API if memory is restricted
@@ -46,5 +46,5 @@ index 603a6f4345ef..ebe01291bf37 100644
  	/*
  	 * In theory, it's possible to have a buggy QEMU-supposed
 -- 
-2.35.1
+2.36.1
 

--- a/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
+++ b/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
@@ -1,4 +1,4 @@
-From a80cccc76accab3b7806ee9d8fc8d7f26eb61d1e Mon Sep 17 00:00:00 2001
+From cc8d37420062b28485032abbdfd27f0c1cd0fb81 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 24 Sep 2021 17:50:39 +0200
 Subject: [PATCH 13/13] Allow booting SEV-ES APs without GHCB (HACK)
@@ -88,5 +88,5 @@ index cc8391f86cdb..3470382c8784 100644
  
  	.section ".text32","ax"
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,4 +1,4 @@
-From 28b6f9d5597e5e05b8133701202b13e8cc23161b Mon Sep 17 00:00:00 2001
+From ab8af3d608f1dd6f51c2bb4b13cc9b4269b68273 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 15:47:50 +0200
 Subject: [PATCH 01/13] krunfw: Don't panic when init dies
@@ -58,5 +58,5 @@ index f7440c0c7e43..a5733d636668 100644
  	machine_restart(cmd);
  }
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,4 +1,4 @@
-From 91cdc5411acfc0adb95c4c92374897c00594854f Mon Sep 17 00:00:00 2001
+From ad327855db5d33084788ba1a6048a152535f8076 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
 Subject: [PATCH 02/13] krunfw: Ignore run_cmd on orderly reboot
@@ -28,5 +28,5 @@ index a5733d636668..989521b0dda7 100644
  	if (ret) {
  		pr_warn("Failed to start orderly reboot: forcing the issue\n");
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,4 +1,4 @@
-From 58b3e04e93a59e6dbef7eda51d0bbf616acbfa0f Mon Sep 17 00:00:00 2001
+From 7e3b76cdc85f31b97bce9345491263f30e141818 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Tue, 6 Apr 2021 23:22:06 +0000
 Subject: [PATCH 03/13] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
@@ -222,5 +222,5 @@ index c5f936fbf876..e70e78d6fd19 100644
  
  static struct virtio_driver virtio_vsock_driver = {
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
+++ b/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
@@ -1,4 +1,4 @@
-From 19de84dcfe67d79934caf6fa0bf73d727a633112 Mon Sep 17 00:00:00 2001
+From cc5cf77b723753eb604decb47bb46ea5d87b81ba Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:43:37 +0200
 Subject: [PATCH 04/13] virtio/vsock: add support for virtio datagram
@@ -986,5 +986,5 @@ index ec2c2afbf0d0..7b62b6f6cc23 100644
  
  	/* Release refcnt obtained when we fetched this socket out of the
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
+++ b/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
@@ -1,4 +1,4 @@
-From 09e3109778ea116412a1510295a08a7f48a16972 Mon Sep 17 00:00:00 2001
+From 195b2c089caefd801215b96e3c851c441a29bf30 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 10 Dec 2021 12:42:16 +0100
 Subject: [PATCH 05/13] vhost/vsock: add support for vhost dgram.
@@ -439,5 +439,5 @@ index 4436c2fd5095..2b9b354b4d56 100644
  		return ret;
  	return misc_register(&vhost_vsock_misc);
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
+++ b/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
@@ -1,4 +1,4 @@
-From 88400d3c7b4f45ecbd7322532671afd2a55f0cef Mon Sep 17 00:00:00 2001
+From 269ca9dfb4248194e739258b3f166370505210a7 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 9 Apr 2021 18:32:20 +0000
 Subject: [PATCH 06/13] vsock_test: add tests for vsock dgram
@@ -372,5 +372,5 @@ index 2a3638c0a008..98d9811747f4 100644
  };
  
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
+++ b/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
@@ -1,4 +1,4 @@
-From 51286e0aa2323a30eba0d58d5e664b99a1f377f1 Mon Sep 17 00:00:00 2001
+From 8eeca940ebf2f45f09a4deed01b6b07be9e4079a Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:46:09 +0200
 Subject: [PATCH 07/13] virtio/vsock: add sysfs for rx buf len for dgram
@@ -97,5 +97,5 @@ index 59b34b7a6500..c050dd570e5e 100644
  
  module_init(virtio_vsock_init);
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
+++ b/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
@@ -1,4 +1,4 @@
-From 97d3c064843707060ea311681212f8334d0fb4ad Mon Sep 17 00:00:00 2001
+From 00d7eb2eebac1289cd91bc5fd8087df8ad9920c5 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:31:03 +0200
 Subject: [PATCH 08/13] virtio/vsock: Fix DGRAM polling
@@ -49,5 +49,5 @@ index 4805e7b23d07..9ee5c1ce64ce 100644
  		}
  
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
+++ b/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
@@ -1,4 +1,4 @@
-From 1c9479d36c38d129aa20d71d31c61fba496ce57d Mon Sep 17 00:00:00 2001
+From 83ed774dd73c936ae52b9caf89b285b175497dfe Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:34:49 +0200
 Subject: [PATCH 09/13] virtio/vsock: add DGRAM to virtio_transport_get_type
@@ -27,5 +27,5 @@ index 7b62b6f6cc23..0ad2f3c31786 100644
  
  /* This function can only be used on connecting/connected sockets,
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -1,4 +1,4 @@
-From fc9753553cf1c7a6b55da3a6a864dcfe2ad28fe9 Mon Sep 17 00:00:00 2001
+From 00f7606c7d509da8f6d06ba3dbe63b5e11c007f1 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
 Subject: [PATCH 10/13] Transparent Socket Impersonation implementation
@@ -1510,5 +1510,5 @@ index 000000000000..cf381734bebe
 +
 +#endif
 -- 
-2.35.1
+2.36.1
 

--- a/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,4 +1,4 @@
-From ee96e972f63797a851139378ea2b01a525910454 Mon Sep 17 00:00:00 2001
+From e028c116d6045ce822dae7ea7edb0966cacaabb0 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
 Subject: [PATCH 11/13] tsi: allow hijacking sockets (tsi_hijack)
@@ -55,5 +55,5 @@ index bb3976abd269..b274930a3691 100644
  	pf = rcu_dereference(net_families[family]);
  	err = -EAFNOSUPPORT;
 -- 
-2.35.1
+2.36.1
 


### PR DESCRIPTION
Rebase the kernel on the latest LTS (5.15.52). This is a clean rebase,
no changes needed in the patches.

Signed-off-by: Sergio Lopez <slp@redhat.com>