### PR TITLE
Rebase kernel on v5.15.57

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-5.15.52
+KERNEL_VERSION = linux-5.15.57
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v5.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
@@ -6,7 +6,7 @@ KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)
 KERNEL_C_BUNDLE = kernel.c
 
 ABI_VERSION=3
-FULL_VERSION=3.1.0
+FULL_VERSION=3.2.0
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,4 +1,4 @@
-From 85faae5803d4aad873e04761a108cb91763edf19 Mon Sep 17 00:00:00 2001
+From 8912884d7254bc132be38828969476849a112f2c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
 Subject: [PATCH 12/13] virtio: enable DMA API if memory is restricted

--- a/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
+++ b/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
@@ -1,4 +1,4 @@
-From cc8d37420062b28485032abbdfd27f0c1cd0fb81 Mon Sep 17 00:00:00 2001
+From 8a35c0e9093c32602c9a615c27f8c760bb41946c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 24 Sep 2021 17:50:39 +0200
 Subject: [PATCH 13/13] Allow booting SEV-ES APs without GHCB (HACK)

--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,4 +1,4 @@
-From ab8af3d608f1dd6f51c2bb4b13cc9b4269b68273 Mon Sep 17 00:00:00 2001
+From b199934cdcf917f17b1681c963d71f902a2ac69e Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 15:47:50 +0200
 Subject: [PATCH 01/13] krunfw: Don't panic when init dies
@@ -16,7 +16,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 7 insertions(+)
 
 diff --git a/kernel/exit.c b/kernel/exit.c
-index 91a43e57a32e..d75d95921ba5 100644
+index aefe7445508d..2a089826b711 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
 @@ -64,6 +64,7 @@

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,4 +1,4 @@
-From ad327855db5d33084788ba1a6048a152535f8076 Mon Sep 17 00:00:00 2001
+From 345015f3f15ae6646e0587c8ec4cdbe043a3bbab Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
 Subject: [PATCH 02/13] krunfw: Ignore run_cmd on orderly reboot

--- a/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,4 +1,4 @@
-From 7e3b76cdc85f31b97bce9345491263f30e141818 Mon Sep 17 00:00:00 2001
+From fe457614431fb6da86577f7bad930b3bc6fdc9c2 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Tue, 6 Apr 2021 23:22:06 +0000
 Subject: [PATCH 03/13] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit

--- a/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
+++ b/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
@@ -1,4 +1,4 @@
-From cc5cf77b723753eb604decb47bb46ea5d87b81ba Mon Sep 17 00:00:00 2001
+From 53f3b976173616855c9a3689e8be01c99dbbeb80 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:43:37 +0200
 Subject: [PATCH 04/13] virtio/vsock: add support for virtio datagram

--- a/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
+++ b/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
@@ -1,4 +1,4 @@
-From 195b2c089caefd801215b96e3c851c441a29bf30 Mon Sep 17 00:00:00 2001
+From 70e45733e03189199edf979e34f2b2e19ec70d32 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 10 Dec 2021 12:42:16 +0100
 Subject: [PATCH 05/13] vhost/vsock: add support for vhost dgram.

--- a/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
+++ b/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
@@ -1,4 +1,4 @@
-From 269ca9dfb4248194e739258b3f166370505210a7 Mon Sep 17 00:00:00 2001
+From ae5c44a42dc6707b6246d93f2567fbb1897971b8 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 9 Apr 2021 18:32:20 +0000
 Subject: [PATCH 06/13] vsock_test: add tests for vsock dgram

--- a/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
+++ b/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
@@ -1,4 +1,4 @@
-From 8eeca940ebf2f45f09a4deed01b6b07be9e4079a Mon Sep 17 00:00:00 2001
+From 352565f9558a85972108f353b9b66718a19874f2 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:46:09 +0200
 Subject: [PATCH 07/13] virtio/vsock: add sysfs for rx buf len for dgram

--- a/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
+++ b/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
@@ -1,4 +1,4 @@
-From 00d7eb2eebac1289cd91bc5fd8087df8ad9920c5 Mon Sep 17 00:00:00 2001
+From 5710b0f126fedb4553e02d45b4d6e285362887b4 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:31:03 +0200
 Subject: [PATCH 08/13] virtio/vsock: Fix DGRAM polling

--- a/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
+++ b/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
@@ -1,4 +1,4 @@
-From 83ed774dd73c936ae52b9caf89b285b175497dfe Mon Sep 17 00:00:00 2001
+From 9cb3bf98829e6cc49c13f4b00b024e33aa26530c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:34:49 +0200
 Subject: [PATCH 09/13] virtio/vsock: add DGRAM to virtio_transport_get_type

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -1,4 +1,4 @@
-From 00f7606c7d509da8f6d06ba3dbe63b5e11c007f1 Mon Sep 17 00:00:00 2001
+From 027e366b9285bd2f0ca6b49f2991afcfa9b4a62b Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
 Subject: [PATCH 10/13] Transparent Socket Impersonation implementation

--- a/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,4 +1,4 @@
-From e028c116d6045ce822dae7ea7edb0966cacaabb0 Mon Sep 17 00:00:00 2001
+From e4a23eca0534daac4c5fc40002d150114cce37a3 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
 Subject: [PATCH 11/13] tsi: allow hijacking sockets (tsi_hijack)


### PR DESCRIPTION
Rebase the kernel on the latest LTS (5.15.57). This is a clean rebase,
no changes needed in the patches.

Signed-off-by: Sergio Lopez <slp@redhat.com>