### PR TITLE
Rebase kernel on v5.15.59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-5.15.57
+KERNEL_VERSION = linux-5.15.59
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v5.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
@@ -6,7 +6,7 @@ KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)
 KERNEL_C_BUNDLE = kernel.c
 
 ABI_VERSION=3
-FULL_VERSION=3.2.0
+FULL_VERSION=3.3.0
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,7 +1,7 @@
-From 8912884d7254bc132be38828969476849a112f2c Mon Sep 17 00:00:00 2001
+From ea1eb601b84ef9d0494388f9676239862eb7a284 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
-Subject: [PATCH 12/13] virtio: enable DMA API if memory is restricted
+Subject: [PATCH 12/14] virtio: enable DMA API if memory is restricted
 
 When running on a system with restricted memory access, the driver
 can't have direct access to the memory. In this scenario,

--- a/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
+++ b/patches-sev/0013-Allow-booting-SEV-ES-APs-without-GHCB-HACK.patch
@@ -1,7 +1,7 @@
-From 8a35c0e9093c32602c9a615c27f8c760bb41946c Mon Sep 17 00:00:00 2001
+From f4874ce3fc4e0465bcbf1ba8abbac7b7c244f954 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 24 Sep 2021 17:50:39 +0200
-Subject: [PATCH 13/13] Allow booting SEV-ES APs without GHCB (HACK)
+Subject: [PATCH 13/14] Allow booting SEV-ES APs without GHCB (HACK)
 
 Allow booting APs with SEV-ES enabled, by setting the trampoline at a
 well-known location, and moving sev_es_trampoline_start to the

--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,7 +1,7 @@
-From b199934cdcf917f17b1681c963d71f902a2ac69e Mon Sep 17 00:00:00 2001
+From f17ab39909568485b61cd4ccd46d78268617cc5f Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 15:47:50 +0200
-Subject: [PATCH 01/13] krunfw: Don't panic when init dies
+Subject: [PATCH 01/14] krunfw: Don't panic when init dies
 
 In libkrun, the isolated process runs as PID 1. When it exits,
 trigger an orderly reboot instead of panic'ing.

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,7 +1,7 @@
-From 345015f3f15ae6646e0587c8ec4cdbe043a3bbab Mon Sep 17 00:00:00 2001
+From 6af67367934c176c98dd881159321e44a02129ef Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
-Subject: [PATCH 02/13] krunfw: Ignore run_cmd on orderly reboot
+Subject: [PATCH 02/14] krunfw: Ignore run_cmd on orderly reboot
 
 We don't really support restarting the conventional way, so ignore
 "run_cmd" so we can fall back to an emergency sync and reboot.

--- a/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,7 +1,7 @@
-From fe457614431fb6da86577f7bad930b3bc6fdc9c2 Mon Sep 17 00:00:00 2001
+From f20552af78ea3e1e0767d21bde9c8c1c393f3336 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Tue, 6 Apr 2021 23:22:06 +0000
-Subject: [PATCH 03/13] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
+Subject: [PATCH 03/14] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
 
 When this feature is enabled, allocate 5 queues,
 otherwise, allocate 3 queues to be compatible with

--- a/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
+++ b/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
@@ -1,7 +1,7 @@
-From 53f3b976173616855c9a3689e8be01c99dbbeb80 Mon Sep 17 00:00:00 2001
+From 8b4b3844be2701a6c21931ea666403195d0cbee1 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:43:37 +0200
-Subject: [PATCH 04/13] virtio/vsock: add support for virtio datagram
+Subject: [PATCH 04/14] virtio/vsock: add support for virtio datagram
 
 This patch add support for virtio dgram for the driver.
 Implemented related functions for tx and rx, enqueue

--- a/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
+++ b/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
@@ -1,7 +1,7 @@
-From 70e45733e03189199edf979e34f2b2e19ec70d32 Mon Sep 17 00:00:00 2001
+From dd378f5699cd9bfad4c1e5e8f28fdf0c292e30ed Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 10 Dec 2021 12:42:16 +0100
-Subject: [PATCH 05/13] vhost/vsock: add support for vhost dgram.
+Subject: [PATCH 05/14] vhost/vsock: add support for vhost dgram.
 
 This patch supports dgram on vhost side, including
 tx and rx. The vhost send packets asynchronously.

--- a/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
+++ b/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
@@ -1,7 +1,7 @@
-From ae5c44a42dc6707b6246d93f2567fbb1897971b8 Mon Sep 17 00:00:00 2001
+From 3f2a457b9bbfbf7b4d70253ee166911eb27d30d9 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 9 Apr 2021 18:32:20 +0000
-Subject: [PATCH 06/13] vsock_test: add tests for vsock dgram
+Subject: [PATCH 06/14] vsock_test: add tests for vsock dgram
 
 Added test cases for vsock dgram types.
 

--- a/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
+++ b/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
@@ -1,7 +1,7 @@
-From 352565f9558a85972108f353b9b66718a19874f2 Mon Sep 17 00:00:00 2001
+From 749c29609a2c90090ebccd0d13199f963566e963 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:46:09 +0200
-Subject: [PATCH 07/13] virtio/vsock: add sysfs for rx buf len for dgram
+Subject: [PATCH 07/14] virtio/vsock: add sysfs for rx buf len for dgram
 
 Make rx buf len configurable via sysfs
 

--- a/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
+++ b/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
@@ -1,7 +1,7 @@
-From 5710b0f126fedb4553e02d45b4d6e285362887b4 Mon Sep 17 00:00:00 2001
+From 406cb3291a432947191ebacfae4c7aad1580ec88 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:31:03 +0200
-Subject: [PATCH 08/13] virtio/vsock: Fix DGRAM polling
+Subject: [PATCH 08/14] virtio/vsock: Fix DGRAM polling
 
 Fix DGRAM polling.
 

--- a/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
+++ b/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
@@ -1,7 +1,7 @@
-From 9cb3bf98829e6cc49c13f4b00b024e33aa26530c Mon Sep 17 00:00:00 2001
+From 2b120f55e46abffa953f4143a3d1e3804a861f29 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:34:49 +0200
-Subject: [PATCH 09/13] virtio/vsock: add DGRAM to virtio_transport_get_type
+Subject: [PATCH 09/14] virtio/vsock: add DGRAM to virtio_transport_get_type
 
 Add missing DGRAM to virtio_transport_get_type.
 

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -1,7 +1,7 @@
-From 027e366b9285bd2f0ca6b49f2991afcfa9b4a62b Mon Sep 17 00:00:00 2001
+From ceae86da3ecea076df2084780c3f6583d4db9b90 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
-Subject: [PATCH 10/13] Transparent Socket Impersonation implementation
+Subject: [PATCH 10/14] Transparent Socket Impersonation implementation
 
 Transparent Socket Impersonation (AF_TSI) is an address family that
 provides sockets presenting two simultaneous personalities, AF_INET

--- a/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,7 +1,7 @@
-From e4a23eca0534daac4c5fc40002d150114cce37a3 Mon Sep 17 00:00:00 2001
+From 63b2ff280ead5443f0e726551ecc4c8b2c5cf5f3 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
-Subject: [PATCH 11/13] tsi: allow hijacking sockets (tsi_hijack)
+Subject: [PATCH 11/14] tsi: allow hijacking sockets (tsi_hijack)
 
 Add a kernel command line option (tsi_hijack) enabling users to
 request the kernel to hijack AF_INET(SOCK_STREAM || SOCK_DGRAM)


### PR DESCRIPTION
Rebase the kernel on the latest LTS (5.15.59). This is a clean rebase,
no changes needed in the patches.

Signed-off-by: Sergio Lopez <slp@redhat.com>