### PR TITLE
Automatically shift to `build_on_krunvm.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ endif
 ARCH = $(shell uname -m)
 OS = $(shell uname -s)
 
+ifeq ($(ARCH),arm64)
+macos-build:
+	echo "Building on macOS, using ./build_on_krunvm.sh"
+	./build_on_krunvm.sh
+endif
+
 KBUNDLE_TYPE_x86_64 = vmlinux
 KBUNDLE_TYPE_aarch64 = Image
 

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,6 @@ endif
 ARCH = $(shell uname -m)
 OS = $(shell uname -s)
 
-ifeq ($(ARCH),arm64)
-macos-build:
-	echo "Building on macOS, using ./build_on_krunvm.sh"
-	./build_on_krunvm.sh
-endif
-
 KBUNDLE_TYPE_x86_64 = vmlinux
 KBUNDLE_TYPE_aarch64 = Image
 
@@ -74,9 +68,15 @@ $(KERNEL_SOURCES): $(KERNEL_TARBALL)
 $(KERNEL_BINARY_$(ARCH)): $(KERNEL_SOURCES)
 	cd $(KERNEL_SOURCES) ; rm -f .version ; $(MAKE) $(MAKEFLAGS) $(KERNEL_FLAGS)
 
+ifeq ($(OS),Darwin)
+$(KERNEL_C_BUNDLE):
+	@echo "Building on macOS, using ./build_on_krunvm.sh"
+	./build_on_krunvm.sh
+else
 $(KERNEL_C_BUNDLE): $(KERNEL_BINARY_$(ARCH))
 	@echo "Generating $(KERNEL_C_BUNDLE) from $(KERNEL_BINARY_$(ARCH))..."
 	@python3 bin2cbundle.py -t $(KBUNDLE_TYPE_$(ARCH)) $(KERNEL_BINARY_$(ARCH)) kernel.c
+endif
 
 ifeq ($(SEV),1)
 $(QBOOT_C_BUNDLE): $(QBOOT_BINARY)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo make SEV=1 install
 
 #### Requirements
 
-Compiling a Linux kernel natively on macOS is not an easy feat. For this reason, the recommended way for building ```libkrunfw``` in this platform is by already having installed a binary version of [krunvm](https://github.com/slp/krunvm) and its dependencies ([libkrun](https://github.com/containers/libkrun), and ```libkrunfw``` itself), such as the one available in the [krunvm Homebrew repo](https://github.com/slp/homebrew-krun), and then executing the [build_on_krunvm.sh](build_on_krunvm.sh) script found in this repository.
+Compiling a Linux kernel natively on macOS is not an easy feat. For this reason, the recommended way for building ```libkrunfw``` in this platform is by already having installed a binary version of [krunvm](https://github.com/containers/krunvm) and its dependencies ([libkrun](https://github.com/containers/libkrun), and ```libkrunfw``` itself), such as the one available in the [krunvm Homebrew repo](https://github.com/slp/homebrew-krun), and then executing the [build_on_krunvm.sh](build_on_krunvm.sh) script found in this repository.
 
 This will create a lightweight Linux VM using ```krunvm``` with the current working directory mapped inside it, and build the kernel on it.
 

--- a/build_on_krunvm.sh
+++ b/build_on_krunvm.sh
@@ -9,6 +9,7 @@ if [ -z "$KRUNVM" ]; then
 	exit -1
 fi
 
+# realpath does not exist by default on macOS, use `brew install coreutils` to get it
 SCRIPTPATH=`realpath $0`
 WORKDIR=`dirname $SCRIPTPATH`
 krunvm create fedora --name libkrunfw-builder --cpus 2 --mem 2048 -v $WORKDIR:/work -w /work

--- a/build_on_krunvm.sh
+++ b/build_on_krunvm.sh
@@ -39,6 +39,4 @@ if [ ! -e "kernel.c" ]; then
 	exit -1
 fi
 
-gcc -fPIC -shared -o libkrunfw.dylib kernel.c
-
 exit 0


### PR DESCRIPTION
This fixes #31 by automatically switching to the appropriate build script.