### PR TITLE
Rebase kernel on v6.1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-6.0.6
+KERNEL_VERSION = linux-6.1.6
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v6.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
@@ -6,8 +6,8 @@ KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)
 KERNEL_C_BUNDLE = kernel.c
 
 ABI_VERSION = 3
-FULL_VERSION = 3.8.1
-TIMESTAMP = "Wed Nov  2 04:44:41 PM UTC 2022"
+FULL_VERSION = 3.9.0
+TIMESTAMP = "Mon Jan 16 05:11:03 PM CET 2023"
 
 KERNEL_FLAGS = KBUILD_BUILD_TIMESTAMP=$(TIMESTAMP)
 KERNEL_FLAGS += KBUILD_BUILD_USER=root

--- a/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,4 +1,4 @@
-From a8c84d27aaaa31fb31cbd1b74d5ff74e9561541a Mon Sep 17 00:00:00 2001
+From 49464719ccf848453bd0fb27b6717b7c8475ef55 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
 Subject: [PATCH 12/15] virtio: enable DMA API if memory is restricted
@@ -32,7 +32,7 @@ index 828ced060742..a22ab612a728 100644
  
  	if (!virtio_has_feature(dev, VIRTIO_F_VERSION_1))
 diff --git a/drivers/virtio/virtio_ring.c b/drivers/virtio/virtio_ring.c
-index 4620e9d79dde..fb9ee0d2a9e1 100644
+index 2e7689bb933b..125425bfd40b 100644
 --- a/drivers/virtio/virtio_ring.c
 +++ b/drivers/virtio/virtio_ring.c
 @@ -6,6 +6,7 @@
@@ -43,7 +43,7 @@ index 4620e9d79dde..fb9ee0d2a9e1 100644
  #include <linux/device.h>
  #include <linux/slab.h>
  #include <linux/module.h>
-@@ -269,6 +270,9 @@ static bool vring_use_dma_api(struct virtio_device *vdev)
+@@ -270,6 +271,9 @@ static bool vring_use_dma_api(struct virtio_device *vdev)
  	if (!virtio_has_dma_quirk(vdev))
  		return true;
  
@@ -54,5 +54,5 @@ index 4620e9d79dde..fb9ee0d2a9e1 100644
  	/*
  	 * In theory, it's possible to have a buggy QEMU-supposed
 -- 
-2.37.3
+2.39.0
 

--- a/patches-sev/0013-x86-sev-write-AP-reset-vector.patch
+++ b/patches-sev/0013-x86-sev-write-AP-reset-vector.patch
@@ -1,4 +1,4 @@
-From 9837737e37d388d3c13d3fdc18986e8ddf74ca19 Mon Sep 17 00:00:00 2001
+From d7d6195b14e02df8e8241085df7fd5dead30ae43 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 20 Oct 2022 10:23:16 +0200
 Subject: [PATCH 13/15] x86/sev: write AP reset vector
@@ -55,5 +55,5 @@ index a428c62330d3..01acde3e78e5 100644
  	/* Check if AP Jump Table is page-aligned */
  	if (jump_table_addr & ~PAGE_MASK)
 -- 
-2.37.3
+2.39.0
 

--- a/patches-sev/0014-Implement-driver-to-retrieve-secrets-from-cmdline.patch
+++ b/patches-sev/0014-Implement-driver-to-retrieve-secrets-from-cmdline.patch
@@ -1,4 +1,4 @@
-From 8e4af045f215100e8a1a45190cd296a18a2fc45f Mon Sep 17 00:00:00 2001
+From 29540b071883ffef59057ea6f754497ae0ba2152 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Wed, 3 Aug 2022 12:35:12 +0200
 Subject: [PATCH 14/15] Implement driver to retrieve secrets from cmdline
@@ -28,7 +28,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  create mode 100644 drivers/virt/coco/cmdline_secret/cmdline_secret.c
 
 diff --git a/arch/x86/kernel/setup.c b/arch/x86/kernel/setup.c
-index 216fee7144ee..1431a956fea0 100644
+index 892609cde4a2..f85ccaa06eac 100644
 --- a/arch/x86/kernel/setup.c
 +++ b/arch/x86/kernel/setup.c
 @@ -886,7 +886,9 @@ void __init setup_arch(char **cmdline_p)
@@ -245,7 +245,7 @@ index 000000000000..e53edce18768
 +module_init(cmdline_secret_init);
 +module_exit(cmdline_secret_exit);
 diff --git a/include/linux/init.h b/include/linux/init.h
-index baf0b29a7010..c8a057a76624 100644
+index 077d7f93b402..31737b9605c3 100644
 --- a/include/linux/init.h
 +++ b/include/linux/init.h
 @@ -143,6 +143,10 @@ struct file_system_type;
@@ -260,10 +260,10 @@ index baf0b29a7010..c8a057a76624 100644
  
  /* used by init/main.c */
 diff --git a/init/main.c b/init/main.c
-index 1fe7942f5d4a..dceacf83ebc5 100644
+index aa21add5f7c5..ebe50e48b2c0 100644
 --- a/init/main.c
 +++ b/init/main.c
-@@ -151,6 +151,11 @@ static char *extra_command_line;
+@@ -153,6 +153,11 @@ static char *extra_command_line;
  /* Extra init arguments */
  static char *extra_init_args;
  
@@ -275,7 +275,7 @@ index 1fe7942f5d4a..dceacf83ebc5 100644
  #ifdef CONFIG_BOOT_CONFIG
  /* Is bootconfig on command line? */
  static bool bootconfig_found;
-@@ -665,6 +670,15 @@ static void __init setup_command_line(char *command_line)
+@@ -667,6 +672,15 @@ static void __init setup_command_line(char *command_line)
  			strcpy(saved_command_line + len, extra_init_args);
  		}
  	}
@@ -292,5 +292,5 @@ index 1fe7942f5d4a..dceacf83ebc5 100644
  
  /*
 -- 
-2.37.3
+2.39.0
 

--- a/patches-sev/0015-x86-sev-Avoid-using-native_cpuid.patch
+++ b/patches-sev/0015-x86-sev-Avoid-using-native_cpuid.patch
@@ -1,7 +1,7 @@
-From 726e542aaedf3616ccd2dd4b04685637adfbdc28 Mon Sep 17 00:00:00 2001
+From 835a346d36ad10d8d6f22aec02ab68704dde4297 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 20 Oct 2022 14:26:54 +0200
-Subject: [PATCH] x86/sev: Avoid using native_cpuid
+Subject: [PATCH 15/15] x86/sev: Avoid using native_cpuid
 
 In the state we get into the kernel from qboot-krunfw we can't return
 from #VC properly, so avoid calling native_cpuid in the early stages
@@ -161,5 +161,5 @@ index f415498d3175..43a2b3febfd1 100644
  }
 +
 -- 
-2.35.1
+2.39.0
 

--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,4 +1,4 @@
-From 5d929eca46d48c02ce43694f6289a45220cfef78 Mon Sep 17 00:00:00 2001
+From b20bfe45b87990231d222cb88a88dcbf19c8bdac Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 15:47:50 +0200
 Subject: [PATCH 01/15] krunfw: Don't panic when init dies
@@ -16,10 +16,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 7 insertions(+)
 
 diff --git a/kernel/exit.c b/kernel/exit.c
-index 84021b24f79e..1021ee02a942 100644
+index 35e0a31a0315..5bd5d63fed88 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
-@@ -66,6 +66,7 @@
+@@ -67,6 +67,7 @@
  #include <linux/io_uring.h>
  #include <linux/kprobes.h>
  #include <linux/rethook.h>
@@ -27,7 +27,7 @@ index 84021b24f79e..1021ee02a942 100644
  
  #include <linux/uaccess.h>
  #include <asm/unistd.h>
-@@ -761,8 +762,12 @@ void __noreturn do_exit(long code)
+@@ -786,8 +787,12 @@ void __noreturn do_exit(long code)
  		 * immediately to get a useable coredump.
  		 */
  		if (unlikely(is_global_init(tsk)))
@@ -41,11 +41,11 @@ index 84021b24f79e..1021ee02a942 100644
  #ifdef CONFIG_POSIX_TIMERS
  		hrtimer_cancel(&tsk->signal->real_timer);
 diff --git a/kernel/reboot.c b/kernel/reboot.c
-index 3c35445bf5ad..496bf5010dd9 100644
+index 3bba88c7ffc6..a08a8a9b4d88 100644
 --- a/kernel/reboot.c
 +++ b/kernel/reboot.c
-@@ -256,10 +256,12 @@ void kernel_restart(char *cmd)
- 	kernel_restart_prepare(cmd);
+@@ -268,10 +268,12 @@ void kernel_restart(char *cmd)
+ 	do_kernel_restart_prepare();
  	migrate_to_reboot_cpu();
  	syscore_shutdown();
 +#ifdef VERBOSE_LIBKRUN
@@ -58,5 +58,5 @@ index 3c35445bf5ad..496bf5010dd9 100644
  	machine_restart(cmd);
  }
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,4 +1,4 @@
-From f8c2754e9cc7f6bb720f2401dec0041d3471f917 Mon Sep 17 00:00:00 2001
+From 19b67c597f1227228ef6b5624d42ddf5c1a6a553 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
 Subject: [PATCH 02/15] krunfw: Ignore run_cmd on orderly reboot
@@ -12,10 +12,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/kernel/reboot.c b/kernel/reboot.c
-index 496bf5010dd9..f22b45c3dde6 100644
+index a08a8a9b4d88..838b7a293e43 100644
 --- a/kernel/reboot.c
 +++ b/kernel/reboot.c
-@@ -818,7 +818,11 @@ static int __orderly_reboot(void)
+@@ -835,7 +835,11 @@ static int __orderly_reboot(void)
  {
  	int ret;
  
@@ -28,5 +28,5 @@ index 496bf5010dd9..f22b45c3dde6 100644
  	if (ret) {
  		pr_warn("Failed to start orderly reboot: forcing the issue\n");
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,4 +1,4 @@
-From e24e19edf93b0cfde43f69c9d457315333a2b35f Mon Sep 17 00:00:00 2001
+From 5a0ce494679c0af63d58cbee014610b6a05b6a84 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Tue, 6 Apr 2021 23:22:06 +0000
 Subject: [PATCH 03/15] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
@@ -17,7 +17,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  4 files changed, 74 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/vhost/vsock.c b/drivers/vhost/vsock.c
-index 5703775af129..a54ac5fc1adf 100644
+index 10a7d23731fe..f02f5a3cd819 100644
 --- a/drivers/vhost/vsock.c
 +++ b/drivers/vhost/vsock.c
 @@ -32,7 +32,8 @@
@@ -207,5 +207,5 @@ index ad64f403536a..3e157a62a9b1 100644
  
  static struct virtio_driver virtio_vsock_driver = {
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
+++ b/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
@@ -1,4 +1,4 @@
-From 63b8b93d7ebb39e208ab0a9f9127769cf1758dc3 Mon Sep 17 00:00:00 2001
+From aa93271828d4233a478198e4b43396ca8a10df7d Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:43:37 +0200
 Subject: [PATCH 04/15] virtio/vsock: add support for virtio datagram
@@ -25,10 +25,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  6 files changed, 458 insertions(+), 72 deletions(-)
 
 diff --git a/include/net/af_vsock.h b/include/net/af_vsock.h
-index 1c53c4c4d88f..86357d915dc8 100644
+index 568a87c5e0d0..9793d30bfe0f 100644
 --- a/include/net/af_vsock.h
 +++ b/include/net/af_vsock.h
-@@ -210,6 +210,7 @@ void vsock_for_each_connected_socket(struct vsock_transport *transport,
+@@ -212,6 +212,7 @@ void vsock_for_each_connected_socket(struct vsock_transport *transport,
  				     void (*fn)(struct sock *sk));
  int vsock_assign_transport(struct vsock_sock *vsk, struct vsock_sock *psk);
  bool vsock_find_cid(unsigned int cid);
@@ -66,7 +66,7 @@ index bcfc76f1e030..291ffe0e1c8a 100644
  
  enum virtio_vsock_op {
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index b4ee163154a6..cbd00ee05ff6 100644
+index 884eca7f6743..ca2e640cdad4 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -675,6 +675,18 @@ static int __vsock_bind_connectible(struct vsock_sock *vsk,
@@ -662,7 +662,7 @@ index 3e157a62a9b1..abaae264453b 100644
  		goto out_wq;
  
 diff --git a/net/vmw_vsock/virtio_transport_common.c b/net/vmw_vsock/virtio_transport_common.c
-index 3a12aee33e92..d3d43f25c247 100644
+index a9980e9b9304..06d4b89c597a 100644
 --- a/net/vmw_vsock/virtio_transport_common.c
 +++ b/net/vmw_vsock/virtio_transport_common.c
 @@ -26,6 +26,8 @@
@@ -847,7 +847,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  static s64 virtio_transport_has_space(struct vsock_sock *vsk)
  {
  	struct virtio_vsock_sock *vvs = vsk->trans;
-@@ -738,13 +860,15 @@ EXPORT_SYMBOL_GPL(virtio_transport_stream_allow);
+@@ -735,13 +857,15 @@ EXPORT_SYMBOL_GPL(virtio_transport_stream_allow);
  int virtio_transport_dgram_bind(struct vsock_sock *vsk,
  				struct sockaddr_vm *addr)
  {
@@ -865,7 +865,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  }
  EXPORT_SYMBOL_GPL(virtio_transport_dgram_allow);
  
-@@ -780,7 +904,17 @@ virtio_transport_dgram_enqueue(struct vsock_sock *vsk,
+@@ -777,7 +901,17 @@ virtio_transport_dgram_enqueue(struct vsock_sock *vsk,
  			       struct msghdr *msg,
  			       size_t dgram_len)
  {
@@ -884,7 +884,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  }
  EXPORT_SYMBOL_GPL(virtio_transport_dgram_enqueue);
  
-@@ -853,7 +987,6 @@ static int virtio_transport_reset_no_sock(const struct virtio_transport *t,
+@@ -850,7 +984,6 @@ static int virtio_transport_reset_no_sock(const struct virtio_transport *t,
  		virtio_transport_free_pkt(reply);
  		return -ENOTCONN;
  	}
@@ -892,7 +892,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  	return t->send_pkt(reply);
  }
  
-@@ -1056,7 +1189,8 @@ virtio_transport_recv_enqueue(struct vsock_sock *vsk,
+@@ -1053,7 +1186,8 @@ virtio_transport_recv_enqueue(struct vsock_sock *vsk,
  		 * of a new message.
  		 */
  		if ((pkt->len <= last_pkt->buf_len - last_pkt->len) &&
@@ -902,7 +902,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  			memcpy(last_pkt->buf + last_pkt->len, pkt->buf,
  			       pkt->len);
  			last_pkt->len += pkt->len;
-@@ -1081,6 +1215,12 @@ virtio_transport_recv_connected(struct sock *sk,
+@@ -1078,6 +1212,12 @@ virtio_transport_recv_connected(struct sock *sk,
  	struct vsock_sock *vsk = vsock_sk(sk);
  	int err = 0;
  
@@ -915,7 +915,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  	switch (le16_to_cpu(pkt->hdr.op)) {
  	case VIRTIO_VSOCK_OP_RW:
  		virtio_transport_recv_enqueue(vsk, pkt);
-@@ -1233,7 +1373,8 @@ virtio_transport_recv_listen(struct sock *sk, struct virtio_vsock_pkt *pkt,
+@@ -1230,7 +1370,8 @@ virtio_transport_recv_listen(struct sock *sk, struct virtio_vsock_pkt *pkt,
  static bool virtio_transport_valid_type(u16 type)
  {
  	return (type == VIRTIO_VSOCK_TYPE_STREAM) ||
@@ -925,7 +925,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  }
  
  /* We are under the virtio-vsock's vsock->rx_lock or vhost-vsock's vq->mutex
-@@ -1296,12 +1437,17 @@ void virtio_transport_recv_pkt(struct virtio_transport *t,
+@@ -1293,12 +1434,17 @@ void virtio_transport_recv_pkt(struct virtio_transport *t,
  		goto free_pkt;
  	}
  
@@ -945,7 +945,7 @@ index 3a12aee33e92..d3d43f25c247 100644
  	if (space_available)
  		sk->sk_write_space(sk);
  
-@@ -1327,6 +1473,7 @@ void virtio_transport_recv_pkt(struct virtio_transport *t,
+@@ -1324,6 +1470,7 @@ void virtio_transport_recv_pkt(struct virtio_transport *t,
  		break;
  	}
  
@@ -954,5 +954,5 @@ index 3a12aee33e92..d3d43f25c247 100644
  
  	/* Release refcnt obtained when we fetched this socket out of the
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
+++ b/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
@@ -1,4 +1,4 @@
-From d5415d216b19ab1a829da47d4c527aa665c31a8d Mon Sep 17 00:00:00 2001
+From d9e0886790ef0c4af98852a8b2657ee6c4b15756 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 10 Dec 2021 12:42:16 +0100
 Subject: [PATCH 05/15] vhost/vsock: add support for vhost dgram.
@@ -16,7 +16,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 185 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/vhost/vsock.c b/drivers/vhost/vsock.c
-index a54ac5fc1adf..84529e6e155d 100644
+index f02f5a3cd819..70720bdb6a63 100644
 --- a/drivers/vhost/vsock.c
 +++ b/drivers/vhost/vsock.c
 @@ -28,7 +28,10 @@
@@ -432,7 +432,7 @@ index a54ac5fc1adf..84529e6e155d 100644
 +				  VSOCK_TRANSPORT_F_H2G | VSOCK_TRANSPORT_F_DGRAM);
  	if (ret < 0)
  		return ret;
- 	return misc_register(&vhost_vsock_misc);
+ 
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
+++ b/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
@@ -1,4 +1,4 @@
-From bc4d197d0c0e7660c462a2ce3b30d417e52842e9 Mon Sep 17 00:00:00 2001
+From a026a9fc5b462b04cd52a3f77243bba3d262c419 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 9 Apr 2021 18:32:20 +0000
 Subject: [PATCH 06/15] vsock_test: add tests for vsock dgram
@@ -10,8 +10,8 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
 ---
  tools/testing/vsock/util.c       | 105 +++++++++++++++++
  tools/testing/vsock/util.h       |   4 +
- tools/testing/vsock/vsock_test.c | 194 +++++++++++++++++++++++++++++++
- 3 files changed, 303 insertions(+)
+ tools/testing/vsock/vsock_test.c | 195 +++++++++++++++++++++++++++++++
+ 3 files changed, 304 insertions(+)
 
 diff --git a/tools/testing/vsock/util.c b/tools/testing/vsock/util.c
 index 2acbb7703c6a..d2f5b223bf85 100644
@@ -153,10 +153,10 @@ index a3375ad2fb7f..7213f2a51c1e 100644
  	       const struct test_opts *opts);
  void list_tests(const struct test_case *test_cases);
 diff --git a/tools/testing/vsock/vsock_test.c b/tools/testing/vsock/vsock_test.c
-index dc577461afc2..57b33231ad5a 100644
+index bb6d691cb30d..c3003adda639 100644
 --- a/tools/testing/vsock/vsock_test.c
 +++ b/tools/testing/vsock/vsock_test.c
-@@ -201,6 +201,115 @@ static void test_stream_server_close_server(const struct test_opts *opts)
+@@ -202,6 +202,115 @@ static void test_stream_server_close_server(const struct test_opts *opts)
  	close(fd);
  }
  
@@ -272,7 +272,7 @@ index dc577461afc2..57b33231ad5a 100644
  /* With the standard socket sizes, VMCI is able to support about 100
   * concurrent stream connections.
   */
-@@ -254,6 +363,77 @@ static void test_stream_multiconn_server(const struct test_opts *opts)
+@@ -255,6 +364,77 @@ static void test_stream_multiconn_server(const struct test_opts *opts)
  		close(fds[i]);
  }
  
@@ -350,11 +350,11 @@ index dc577461afc2..57b33231ad5a 100644
  static void test_stream_msg_peek_client(const struct test_opts *opts)
  {
  	int fd;
-@@ -645,6 +825,20 @@ static struct test_case test_cases[] = {
- 		.name = "SOCK_SEQPACKET invalid receive buffer",
- 		.run_client = test_seqpacket_invalid_rec_buffer_client,
- 		.run_server = test_seqpacket_invalid_rec_buffer_server,
-+	},
+@@ -754,6 +934,21 @@ static struct test_case test_cases[] = {
+ 		.run_client = test_stream_poll_rcvlowat_client,
+ 		.run_server = test_stream_poll_rcvlowat_server,
+ 	},
++	{
 +		.name = "SOCK_DGRAM client close",
 +		.run_client = test_dgram_sendto_client,
 +		.run_server = test_dgram_sendto_server,
@@ -368,9 +368,10 @@ index dc577461afc2..57b33231ad5a 100644
 +		.name = "SOCK_DGRAM multiple connections",
 +		.run_client = test_dgram_multiconn_client,
 +		.run_server = test_dgram_multiconn_server,
- 	},
++	},
  	{},
  };
+ 
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
+++ b/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
@@ -1,4 +1,4 @@
-From 88be440007f53b5feb603ba59aaee343d3741b1e Mon Sep 17 00:00:00 2001
+From 7aa58f247ca7bb48d5b38bd703ae71c8b28d50e2 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:46:09 +0200
 Subject: [PATCH 07/15] virtio/vsock: add sysfs for rx buf len for dgram
@@ -97,5 +97,5 @@ index abaae264453b..5e78e9ca3e2b 100644
  
  module_init(virtio_vsock_init);
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
+++ b/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
@@ -1,4 +1,4 @@
-From 2067e37de08c43778c17cbf8129c94661fc9a17b Mon Sep 17 00:00:00 2001
+From 26abb89be95fa4f8896e0ba258d1cf5bb0ed2ef1 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:31:03 +0200
 Subject: [PATCH 08/15] virtio/vsock: Fix DGRAM polling
@@ -11,10 +11,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 21 insertions(+), 5 deletions(-)
 
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index cbd00ee05ff6..230cc6e23674 100644
+index ca2e640cdad4..9690a39153a7 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
-@@ -1048,12 +1048,28 @@ static __poll_t vsock_poll(struct file *file, struct socket *sock,
+@@ -1058,12 +1058,28 @@ static __poll_t vsock_poll(struct file *file, struct socket *sock,
  	}
  
  	if (sock->type == SOCK_DGRAM) {
@@ -49,5 +49,5 @@ index cbd00ee05ff6..230cc6e23674 100644
  		}
  
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
+++ b/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
@@ -1,4 +1,4 @@
-From d7c79548a124c727605182606353f465688aa4d4 Mon Sep 17 00:00:00 2001
+From 31ad56a4323ce6269187fe24849d4679b4fe6d3d Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:34:49 +0200
 Subject: [PATCH 09/15] virtio/vsock: add DGRAM to virtio_transport_get_type
@@ -11,7 +11,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/net/vmw_vsock/virtio_transport_common.c b/net/vmw_vsock/virtio_transport_common.c
-index d3d43f25c247..7e96c6cdd4d4 100644
+index 06d4b89c597a..5e31e789b007 100644
 --- a/net/vmw_vsock/virtio_transport_common.c
 +++ b/net/vmw_vsock/virtio_transport_common.c
 @@ -179,8 +179,10 @@ static u16 virtio_transport_get_type(struct sock *sk)
@@ -27,5 +27,5 @@ index d3d43f25c247..7e96c6cdd4d4 100644
  
  /* This function can only be used on connecting/connected sockets,
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -1,4 +1,4 @@
-From 3ab87ed90ad286b50a8f0fa943ae33212cfb0e35 Mon Sep 17 00:00:00 2001
+From 693b52bd33f75634ea41e1999589c0e97018cd90 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
 Subject: [PATCH 10/15] Transparent Socket Impersonation implementation
@@ -60,10 +60,10 @@ index de3701a2a212..3412fca9a223 100644
  
  /* Maximum queue length specifiable by listen.  */
 diff --git a/net/Kconfig b/net/Kconfig
-index 6b78f695caa6..87042aac730f 100644
+index 48c33c222199..0cd0eacfa927 100644
 --- a/net/Kconfig
 +++ b/net/Kconfig
-@@ -244,6 +244,7 @@ source "net/switchdev/Kconfig"
+@@ -242,6 +242,7 @@ source "net/switchdev/Kconfig"
  source "net/l3mdev/Kconfig"
  source "net/qrtr/Kconfig"
  source "net/ncsi/Kconfig"
@@ -72,16 +72,16 @@ index 6b78f695caa6..87042aac730f 100644
  config PCPU_DEV_REFCNT
  	bool "Use percpu variables to maintain network device refcount"
 diff --git a/net/Makefile b/net/Makefile
-index fbfeb8a0bb37..93b06ded75ad 100644
+index 6a62e5b27378..6e3d19c62528 100644
 --- a/net/Makefile
 +++ b/net/Makefile
-@@ -79,3 +79,4 @@ obj-$(CONFIG_NET_NCSI)		+= ncsi/
+@@ -78,3 +78,4 @@ obj-$(CONFIG_NET_NCSI)		+= ncsi/
  obj-$(CONFIG_XDP_SOCKETS)	+= xdp/
  obj-$(CONFIG_MPTCP)		+= mptcp/
  obj-$(CONFIG_MCTP)		+= mctp/
 +obj-$(CONFIG_TSI)		+= tsi/
 diff --git a/net/socket.c b/net/socket.c
-index 7378375d3a5b..52d9e5b070cb 100644
+index 00da9ce3dba0..5ea92b3f8e0d 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -214,6 +214,7 @@ static const char * const pf_family_names[] = {
@@ -1510,5 +1510,5 @@ index 000000000000..cf381734bebe
 +
 +#endif
 -- 
-2.37.3
+2.39.0
 

--- a/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,4 +1,4 @@
-From 4268a38385167efb9fc664ed5d14787e030b86ed Mon Sep 17 00:00:00 2001
+From d34d84670f5c0eb5c6be845c3026669dd0e10f8d Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
 Subject: [PATCH 11/15] tsi: allow hijacking sockets (tsi_hijack)
@@ -14,7 +14,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/net/socket.c b/net/socket.c
-index 52d9e5b070cb..d3ae41f24eed 100644
+index 5ea92b3f8e0d..27821480bf63 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -112,6 +112,10 @@ unsigned int sysctl_net_busy_read __read_mostly;
@@ -69,5 +69,5 @@ index 38a383634ccd..91c9c5cb2285 100644
  	int err;
  
 -- 
-2.37.3
+2.39.0
 


### PR DESCRIPTION
Rebase on the latest stable kernel (6.1.6). This is significant jump from 6.0.6, but luckily the patchset only required very minor changes.

As we're jumping to a newer kernel series, bump minor version too. We're now at 3.9.0.

Signed-off-by: Sergio Lopez <slp@redhat.com>