### PR TITLE
Rebase kernel on v6.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-6.1.6
+KERNEL_VERSION = linux-6.2.1
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v6.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
@@ -6,8 +6,8 @@ KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)
 KERNEL_C_BUNDLE = kernel.c
 
 ABI_VERSION = 3
-FULL_VERSION = 3.9.0
-TIMESTAMP = "Mon Jan 16 05:11:03 PM CET 2023"
+FULL_VERSION = 3.10.0
+TIMESTAMP = "Thu Mar  2 10:46:27 CET 2023"
 
 KERNEL_FLAGS = KBUILD_BUILD_TIMESTAMP=$(TIMESTAMP)
 KERNEL_FLAGS += KBUILD_BUILD_USER=root

--- a/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,4 +1,4 @@
-From 49464719ccf848453bd0fb27b6717b7c8475ef55 Mon Sep 17 00:00:00 2001
+From b81abacd8b63f96665925582f8b649189ac55d6c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
 Subject: [PATCH 12/15] virtio: enable DMA API if memory is restricted
@@ -15,7 +15,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 4 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/virtio/virtio.c b/drivers/virtio/virtio.c
-index 828ced060742..a22ab612a728 100644
+index b9a80aedee1b..6adf39d2ecb6 100644
 --- a/drivers/virtio/virtio.c
 +++ b/drivers/virtio/virtio.c
 @@ -180,12 +180,6 @@ static int virtio_features_ok(struct virtio_device *dev)
@@ -32,7 +32,7 @@ index 828ced060742..a22ab612a728 100644
  
  	if (!virtio_has_feature(dev, VIRTIO_F_VERSION_1))
 diff --git a/drivers/virtio/virtio_ring.c b/drivers/virtio/virtio_ring.c
-index 2e7689bb933b..125425bfd40b 100644
+index 723c4e29e1d3..cb8a213e3412 100644
 --- a/drivers/virtio/virtio_ring.c
 +++ b/drivers/virtio/virtio_ring.c
 @@ -6,6 +6,7 @@
@@ -54,5 +54,5 @@ index 2e7689bb933b..125425bfd40b 100644
  	/*
  	 * In theory, it's possible to have a buggy QEMU-supposed
 -- 
-2.39.0
+2.35.1
 

--- a/patches-sev/0013-x86-sev-write-AP-reset-vector.patch
+++ b/patches-sev/0013-x86-sev-write-AP-reset-vector.patch
@@ -1,4 +1,4 @@
-From d7d6195b14e02df8e8241085df7fd5dead30ae43 Mon Sep 17 00:00:00 2001
+From 26577be5f70564d4fb9bf6391a55a2e240b94d1c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 20 Oct 2022 10:23:16 +0200
 Subject: [PATCH 13/15] x86/sev: write AP reset vector
@@ -12,7 +12,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/sev.c b/arch/x86/kernel/sev.c
-index a428c62330d3..01acde3e78e5 100644
+index 679026a640ef..6663d75529d6 100644
 --- a/arch/x86/kernel/sev.c
 +++ b/arch/x86/kernel/sev.c
 @@ -1144,6 +1144,29 @@ void snp_set_wakeup_secondary_cpu(void)
@@ -55,5 +55,5 @@ index a428c62330d3..01acde3e78e5 100644
  	/* Check if AP Jump Table is page-aligned */
  	if (jump_table_addr & ~PAGE_MASK)
 -- 
-2.39.0
+2.35.1
 

--- a/patches-sev/0014-Implement-driver-to-retrieve-secrets-from-cmdline.patch
+++ b/patches-sev/0014-Implement-driver-to-retrieve-secrets-from-cmdline.patch
@@ -1,7 +1,7 @@
-From 29540b071883ffef59057ea6f754497ae0ba2152 Mon Sep 17 00:00:00 2001
+From 53cb2328116dfab16e45f196a839ce525f4d4431 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
-Date: Wed, 3 Aug 2022 12:35:12 +0200
-Subject: [PATCH 14/15] Implement driver to retrieve secrets from cmdline
+Date: Thu, 2 Mar 2023 12:06:44 +0100
+Subject: [PATCH 1/2] Implement driver to retrieve secrets from cmdline
 
 When CMDLINE_OVERRIDE is enabled, the contents originally present in
 the location passed on the cmdline pointer of the zero page are
@@ -28,10 +28,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  create mode 100644 drivers/virt/coco/cmdline_secret/cmdline_secret.c
 
 diff --git a/arch/x86/kernel/setup.c b/arch/x86/kernel/setup.c
-index 892609cde4a2..f85ccaa06eac 100644
+index 88188549647c..5f044be04f08 100644
 --- a/arch/x86/kernel/setup.c
 +++ b/arch/x86/kernel/setup.c
-@@ -886,7 +886,9 @@ void __init setup_arch(char **cmdline_p)
+@@ -888,7 +888,9 @@ void __init setup_arch(char **cmdline_p)
  	 */
  	__flush_tlb_all();
  #else
@@ -41,7 +41,7 @@ index 892609cde4a2..f85ccaa06eac 100644
  	boot_cpu_data.x86_phys_bits = MAX_PHYSMEM_BITS;
  #endif
  
-@@ -971,6 +973,11 @@ void __init setup_arch(char **cmdline_p)
+@@ -973,6 +975,11 @@ void __init setup_arch(char **cmdline_p)
  
  #ifdef CONFIG_CMDLINE_BOOL
  #ifdef CONFIG_CMDLINE_OVERRIDE
@@ -54,7 +54,7 @@ index 892609cde4a2..f85ccaa06eac 100644
  #else
  	if (builtin_cmdline[0]) {
 diff --git a/drivers/virt/Kconfig b/drivers/virt/Kconfig
-index 87ef258cec64..c263c395a843 100644
+index f79ab13a5c28..4a62feec1a0e 100644
 --- a/drivers/virt/Kconfig
 +++ b/drivers/virt/Kconfig
 @@ -50,6 +50,8 @@ source "drivers/virt/acrn/Kconfig"
@@ -65,17 +65,18 @@ index 87ef258cec64..c263c395a843 100644
 +
  source "drivers/virt/coco/sev-guest/Kconfig"
  
- endif
+ source "drivers/virt/coco/tdx-guest/Kconfig"
 diff --git a/drivers/virt/Makefile b/drivers/virt/Makefile
-index 093674e05c40..b56e956825b1 100644
+index e9aa6fc96fab..9174d4f9286e 100644
 --- a/drivers/virt/Makefile
 +++ b/drivers/virt/Makefile
-@@ -10,4 +10,5 @@ obj-y				+= vboxguest/
+@@ -10,5 +10,6 @@ obj-y				+= vboxguest/
  obj-$(CONFIG_NITRO_ENCLAVES)	+= nitro_enclaves/
  obj-$(CONFIG_ACRN_HSM)		+= acrn/
  obj-$(CONFIG_EFI_SECRET)	+= coco/efi_secret/
 +obj-$(CONFIG_CMDLINE_SECRET)	+= coco/cmdline_secret/
  obj-$(CONFIG_SEV_GUEST)		+= coco/sev-guest/
+ obj-$(CONFIG_INTEL_TDX_GUEST)	+= coco/tdx-guest/
 diff --git a/drivers/virt/coco/cmdline_secret/Kconfig b/drivers/virt/coco/cmdline_secret/Kconfig
 new file mode 100644
 index 000000000000..bb601280d50d
@@ -245,13 +246,13 @@ index 000000000000..e53edce18768
 +module_init(cmdline_secret_init);
 +module_exit(cmdline_secret_exit);
 diff --git a/include/linux/init.h b/include/linux/init.h
-index 077d7f93b402..31737b9605c3 100644
+index c5fe6d26f5b1..a30efcccd958 100644
 --- a/include/linux/init.h
 +++ b/include/linux/init.h
-@@ -143,6 +143,10 @@ struct file_system_type;
- extern int do_one_initcall(initcall_t fn);
+@@ -146,6 +146,10 @@ extern int do_one_initcall(initcall_t fn);
  extern char __initdata boot_command_line[];
  extern char *saved_command_line;
+ extern unsigned int saved_command_line_len;
 +#if defined(CONFIG_CMDLINE_SECRET)
 +extern char __initdata early_secret_cmdline[];
 +extern char *secret_cmdline;
@@ -260,10 +261,10 @@ index 077d7f93b402..31737b9605c3 100644
  
  /* used by init/main.c */
 diff --git a/init/main.c b/init/main.c
-index aa21add5f7c5..ebe50e48b2c0 100644
+index e1c3911d7c70..d38f44330a89 100644
 --- a/init/main.c
 +++ b/init/main.c
-@@ -153,6 +153,11 @@ static char *extra_command_line;
+@@ -154,6 +154,11 @@ static char *extra_command_line;
  /* Extra init arguments */
  static char *extra_init_args;
  
@@ -275,10 +276,10 @@ index aa21add5f7c5..ebe50e48b2c0 100644
  #ifdef CONFIG_BOOT_CONFIG
  /* Is bootconfig on command line? */
  static bool bootconfig_found;
-@@ -667,6 +672,15 @@ static void __init setup_command_line(char *command_line)
- 			strcpy(saved_command_line + len, extra_init_args);
- 		}
+@@ -670,6 +675,15 @@ static void __init setup_command_line(char *command_line)
  	}
+ 
+ 	saved_command_line_len = strlen(saved_command_line);
 +
 +#ifdef CONFIG_CMDLINE_SECRET
 +	secret_cmdline = memblock_alloc(COMMAND_LINE_SIZE, SMP_CACHE_BYTES);

--- a/patches-sev/0015-x86-sev-Avoid-using-native_cpuid.patch
+++ b/patches-sev/0015-x86-sev-Avoid-using-native_cpuid.patch
@@ -1,7 +1,7 @@
-From 835a346d36ad10d8d6f22aec02ab68704dde4297 Mon Sep 17 00:00:00 2001
+From 6627abe4c66533d3916a30a03f98daf560120a0f Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 20 Oct 2022 14:26:54 +0200
-Subject: [PATCH 15/15] x86/sev: Avoid using native_cpuid
+Subject: [PATCH 2/2] x86/sev: Avoid using native_cpuid
 
 In the state we get into the kernel from qboot-krunfw we can't return
 from #VC properly, so avoid calling native_cpuid in the early stages
@@ -16,7 +16,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 26 insertions(+), 87 deletions(-)
 
 diff --git a/arch/x86/mm/mem_encrypt_identity.c b/arch/x86/mm/mem_encrypt_identity.c
-index f415498d3175..43a2b3febfd1 100644
+index 88cccd65029d..471ebf438010 100644
 --- a/arch/x86/mm/mem_encrypt_identity.c
 +++ b/arch/x86/mm/mem_encrypt_identity.c
 @@ -504,114 +504,53 @@ void __init sme_encrypt_kernel(struct boot_params *bp)

--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,6 +1,6 @@
-From b20bfe45b87990231d222cb88a88dcbf19c8bdac Mon Sep 17 00:00:00 2001
+From 6cdbce21bba4a756ccb4b7e2ba199898543a24b5 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
-Date: Mon, 16 May 2022 15:47:50 +0200
+Date: Thu, 2 Mar 2023 07:34:49 +0100
 Subject: [PATCH 01/15] krunfw: Don't panic when init dies
 
 In libkrun, the isolated process runs as PID 1. When it exits,
@@ -16,18 +16,18 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 7 insertions(+)
 
 diff --git a/kernel/exit.c b/kernel/exit.c
-index 35e0a31a0315..5bd5d63fed88 100644
+index 15dc2ec80c46..caf35fe8ff5d 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
-@@ -67,6 +67,7 @@
- #include <linux/io_uring.h>
+@@ -68,6 +68,7 @@
  #include <linux/kprobes.h>
  #include <linux/rethook.h>
+ #include <linux/sysfs.h>
 +#include <linux/reboot.h>
  
  #include <linux/uaccess.h>
  #include <asm/unistd.h>
-@@ -786,8 +787,12 @@ void __noreturn do_exit(long code)
+@@ -833,8 +834,12 @@ void __noreturn do_exit(long code)
  		 * immediately to get a useable coredump.
  		 */
  		if (unlikely(is_global_init(tsk)))
@@ -58,5 +58,5 @@ index 3bba88c7ffc6..a08a8a9b4d88 100644
  	machine_restart(cmd);
  }
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,4 +1,4 @@
-From 19b67c597f1227228ef6b5624d42ddf5c1a6a553 Mon Sep 17 00:00:00 2001
+From 3a15e5dfa3dcae76b334d0010644af520ba2666d Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
 Subject: [PATCH 02/15] krunfw: Ignore run_cmd on orderly reboot
@@ -28,5 +28,5 @@ index a08a8a9b4d88..838b7a293e43 100644
  	if (ret) {
  		pr_warn("Failed to start orderly reboot: forcing the issue\n");
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,4 +1,4 @@
-From 5a0ce494679c0af63d58cbee014610b6a05b6a84 Mon Sep 17 00:00:00 2001
+From 874ad1e79038e3888332a289993564f4be2affc8 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Tue, 6 Apr 2021 23:22:06 +0000
 Subject: [PATCH 03/15] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
@@ -17,7 +17,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  4 files changed, 74 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/vhost/vsock.c b/drivers/vhost/vsock.c
-index 10a7d23731fe..f02f5a3cd819 100644
+index a2b374372363..c2353f2ac4e1 100644
 --- a/drivers/vhost/vsock.c
 +++ b/drivers/vhost/vsock.c
 @@ -32,7 +32,8 @@
@@ -207,5 +207,5 @@ index ad64f403536a..3e157a62a9b1 100644
  
  static struct virtio_driver virtio_vsock_driver = {
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
+++ b/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
@@ -1,4 +1,4 @@
-From aa93271828d4233a478198e4b43396ca8a10df7d Mon Sep 17 00:00:00 2001
+From 39c8fb37486e07684b806b6bac7ef591bc749bb6 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:43:37 +0200
 Subject: [PATCH 04/15] virtio/vsock: add support for virtio datagram
@@ -66,10 +66,10 @@ index bcfc76f1e030..291ffe0e1c8a 100644
  
  enum virtio_vsock_op {
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 884eca7f6743..ca2e640cdad4 100644
+index d593d5b6d4b1..0fd3df91f52f 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
-@@ -675,6 +675,18 @@ static int __vsock_bind_connectible(struct vsock_sock *vsk,
+@@ -674,6 +674,18 @@ static int __vsock_bind_connectible(struct vsock_sock *vsk,
  	return 0;
  }
  
@@ -954,5 +954,5 @@ index a9980e9b9304..06d4b89c597a 100644
  
  	/* Release refcnt obtained when we fetched this socket out of the
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
+++ b/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
@@ -1,4 +1,4 @@
-From d9e0886790ef0c4af98852a8b2657ee6c4b15756 Mon Sep 17 00:00:00 2001
+From 92e3f99f86081bbc4c36ef726a551371c87e1082 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 10 Dec 2021 12:42:16 +0100
 Subject: [PATCH 05/15] vhost/vsock: add support for vhost dgram.
@@ -16,7 +16,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 185 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/vhost/vsock.c b/drivers/vhost/vsock.c
-index f02f5a3cd819..70720bdb6a63 100644
+index c2353f2ac4e1..64fd52182ce8 100644
 --- a/drivers/vhost/vsock.c
 +++ b/drivers/vhost/vsock.c
 @@ -28,7 +28,10 @@
@@ -434,5 +434,5 @@ index f02f5a3cd819..70720bdb6a63 100644
  		return ret;
  
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
+++ b/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
@@ -1,4 +1,4 @@
-From a026a9fc5b462b04cd52a3f77243bba3d262c419 Mon Sep 17 00:00:00 2001
+From 673f31c7e600447681fb632b7c49827d536dbca3 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 9 Apr 2021 18:32:20 +0000
 Subject: [PATCH 06/15] vsock_test: add tests for vsock dgram
@@ -373,5 +373,5 @@ index bb6d691cb30d..c3003adda639 100644
  };
  
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
+++ b/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
@@ -1,4 +1,4 @@
-From 7aa58f247ca7bb48d5b38bd703ae71c8b28d50e2 Mon Sep 17 00:00:00 2001
+From d5aec35f074af2463e35db8f805b19fd7c1a1bdb Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:46:09 +0200
 Subject: [PATCH 07/15] virtio/vsock: add sysfs for rx buf len for dgram
@@ -97,5 +97,5 @@ index abaae264453b..5e78e9ca3e2b 100644
  
  module_init(virtio_vsock_init);
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
+++ b/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
@@ -1,4 +1,4 @@
-From 26abb89be95fa4f8896e0ba258d1cf5bb0ed2ef1 Mon Sep 17 00:00:00 2001
+From a315169e2a45d4e6628593184bb9f3797589dcd6 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:31:03 +0200
 Subject: [PATCH 08/15] virtio/vsock: Fix DGRAM polling
@@ -11,10 +11,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 21 insertions(+), 5 deletions(-)
 
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index ca2e640cdad4..9690a39153a7 100644
+index 0fd3df91f52f..d4210968809b 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
-@@ -1058,12 +1058,28 @@ static __poll_t vsock_poll(struct file *file, struct socket *sock,
+@@ -1057,12 +1057,28 @@ static __poll_t vsock_poll(struct file *file, struct socket *sock,
  	}
  
  	if (sock->type == SOCK_DGRAM) {
@@ -49,5 +49,5 @@ index ca2e640cdad4..9690a39153a7 100644
  		}
  
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
+++ b/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
@@ -1,4 +1,4 @@
-From 31ad56a4323ce6269187fe24849d4679b4fe6d3d Mon Sep 17 00:00:00 2001
+From acf7832d984064649ff03c5b2440c8eed85f15d4 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:34:49 +0200
 Subject: [PATCH 09/15] virtio/vsock: add DGRAM to virtio_transport_get_type
@@ -27,5 +27,5 @@ index 06d4b89c597a..5e31e789b007 100644
  
  /* This function can only be used on connecting/connected sockets,
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -1,4 +1,4 @@
-From 693b52bd33f75634ea41e1999589c0e97018cd90 Mon Sep 17 00:00:00 2001
+From 96ad1b3abeae77a04cd16d559eee2abf716a740a Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
 Subject: [PATCH 10/15] Transparent Socket Impersonation implementation
@@ -37,10 +37,10 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  create mode 100644 net/tsi/af_tsi.h
 
 diff --git a/include/linux/socket.h b/include/linux/socket.h
-index de3701a2a212..3412fca9a223 100644
+index 13c3a237b9c9..5fdca5e4e768 100644
 --- a/include/linux/socket.h
 +++ b/include/linux/socket.h
-@@ -235,8 +235,9 @@ struct ucred {
+@@ -238,8 +238,9 @@ struct ucred {
  #define AF_MCTP		45	/* Management component
  				 * transport protocol
  				 */
@@ -51,7 +51,7 @@ index de3701a2a212..3412fca9a223 100644
  
  /* Protocol families, same as address families. */
  #define PF_UNSPEC	AF_UNSPEC
-@@ -287,6 +288,7 @@ struct ucred {
+@@ -290,6 +291,7 @@ struct ucred {
  #define PF_SMC		AF_SMC
  #define PF_XDP		AF_XDP
  #define PF_MCTP		AF_MCTP
@@ -81,7 +81,7 @@ index 6a62e5b27378..6e3d19c62528 100644
  obj-$(CONFIG_MCTP)		+= mctp/
 +obj-$(CONFIG_TSI)		+= tsi/
 diff --git a/net/socket.c b/net/socket.c
-index 00da9ce3dba0..5ea92b3f8e0d 100644
+index c12af3c84d3a..f4c821fac342 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -214,6 +214,7 @@ static const char * const pf_family_names[] = {
@@ -1510,5 +1510,5 @@ index 000000000000..cf381734bebe
 +
 +#endif
 -- 
-2.39.0
+2.35.1
 

--- a/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,4 +1,4 @@
-From d34d84670f5c0eb5c6be845c3026669dd0e10f8d Mon Sep 17 00:00:00 2001
+From ad50560b45673f182b882f3ac6426391d117cfe2 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
 Subject: [PATCH 11/15] tsi: allow hijacking sockets (tsi_hijack)
@@ -14,7 +14,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/net/socket.c b/net/socket.c
-index 5ea92b3f8e0d..27821480bf63 100644
+index f4c821fac342..72c4c6db0349 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -112,6 +112,10 @@ unsigned int sysctl_net_busy_read __read_mostly;
@@ -28,7 +28,7 @@ index 5ea92b3f8e0d..27821480bf63 100644
  static ssize_t sock_read_iter(struct kiocb *iocb, struct iov_iter *to);
  static ssize_t sock_write_iter(struct kiocb *iocb, struct iov_iter *from);
  static int sock_mmap(struct file *file, struct vm_area_struct *vma);
-@@ -1427,6 +1431,10 @@ int sock_wake_async(struct socket_wq *wq, int how, int band)
+@@ -1430,6 +1434,10 @@ int sock_wake_async(struct socket_wq *wq, int how, int band)
  }
  EXPORT_SYMBOL(sock_wake_async);
  
@@ -39,7 +39,7 @@ index 5ea92b3f8e0d..27821480bf63 100644
  /**
   *	__sock_create - creates a socket
   *	@net: net namespace
-@@ -1497,6 +1505,15 @@ int __sock_create(struct net *net, int family, int type, int protocol,
+@@ -1500,6 +1508,15 @@ int __sock_create(struct net *net, int family, int type, int protocol,
  		request_module("net-pf-%d", family);
  #endif
  
@@ -69,5 +69,5 @@ index 38a383634ccd..91c9c5cb2285 100644
  	int err;
  
 -- 
-2.39.0
+2.35.1
 


### PR DESCRIPTION
Rebase on the latest stable kernel (6.2.1). No big changes were required on the downstream patches.

Bump minor version to reflect the newer kernel, now at 3.10.0.