### PR TITLE
Rebase kernel on v6.2.9 and update initrd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KERNEL_VERSION = linux-6.2.1
+KERNEL_VERSION = linux-6.2.9
 KERNEL_REMOTE = https://cdn.kernel.org/pub/linux/kernel/v6.x/$(KERNEL_VERSION).tar.xz
 KERNEL_TARBALL = tarballs/$(KERNEL_VERSION).tar.xz
 KERNEL_SOURCES = $(KERNEL_VERSION)
@@ -6,8 +6,8 @@ KERNEL_PATCHES = $(shell find patches/ -name "0*.patch" | sort)
 KERNEL_C_BUNDLE = kernel.c
 
 ABI_VERSION = 3
-FULL_VERSION = 3.10.0
-TIMESTAMP = "Thu Mar  2 10:46:27 CET 2023"
+FULL_VERSION = 3.11.0
+TIMESTAMP = "Mon Apr  3 04:28:59 PM CEST 2023"
 
 KERNEL_FLAGS = KBUILD_BUILD_TIMESTAMP=$(TIMESTAMP)
 KERNEL_FLAGS += KBUILD_BUILD_USER=root

--- a/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-sev/0012-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,4 +1,4 @@
-From b81abacd8b63f96665925582f8b649189ac55d6c Mon Sep 17 00:00:00 2001
+From 9fa36ea0f90061f387dd9d68bf2a20ff9d8ac53a Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
 Subject: [PATCH 12/15] virtio: enable DMA API if memory is restricted
@@ -54,5 +54,5 @@ index 723c4e29e1d3..cb8a213e3412 100644
  	/*
  	 * In theory, it's possible to have a buggy QEMU-supposed
 -- 
-2.35.1
+2.39.2
 

--- a/patches-sev/0013-x86-sev-write-AP-reset-vector.patch
+++ b/patches-sev/0013-x86-sev-write-AP-reset-vector.patch
@@ -1,4 +1,4 @@
-From 26577be5f70564d4fb9bf6391a55a2e240b94d1c Mon Sep 17 00:00:00 2001
+From a4853e8c504fb0f19ba731c068ec9e680338e9f9 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 20 Oct 2022 10:23:16 +0200
 Subject: [PATCH 13/15] x86/sev: write AP reset vector
@@ -12,7 +12,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/sev.c b/arch/x86/kernel/sev.c
-index 679026a640ef..6663d75529d6 100644
+index 3f664ab277c4..8770bdbdf1e2 100644
 --- a/arch/x86/kernel/sev.c
 +++ b/arch/x86/kernel/sev.c
 @@ -1144,6 +1144,29 @@ void snp_set_wakeup_secondary_cpu(void)
@@ -55,5 +55,5 @@ index 679026a640ef..6663d75529d6 100644
  	/* Check if AP Jump Table is page-aligned */
  	if (jump_table_addr & ~PAGE_MASK)
 -- 
-2.35.1
+2.39.2
 

--- a/patches-sev/0014-Implement-driver-to-retrieve-secrets-from-cmdline.patch
+++ b/patches-sev/0014-Implement-driver-to-retrieve-secrets-from-cmdline.patch
@@ -1,7 +1,7 @@
-From 53cb2328116dfab16e45f196a839ce525f4d4431 Mon Sep 17 00:00:00 2001
+From e43f174c9736d474b4b2e353198378f3947df320 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 2 Mar 2023 12:06:44 +0100
-Subject: [PATCH 1/2] Implement driver to retrieve secrets from cmdline
+Subject: [PATCH 14/15] Implement driver to retrieve secrets from cmdline
 
 When CMDLINE_OVERRIDE is enabled, the contents originally present in
 the location passed on the cmdline pointer of the zero page are
@@ -293,5 +293,5 @@ index e1c3911d7c70..d38f44330a89 100644
  
  /*
 -- 
-2.39.0
+2.39.2
 

--- a/patches-sev/0015-x86-sev-Avoid-using-native_cpuid.patch
+++ b/patches-sev/0015-x86-sev-Avoid-using-native_cpuid.patch
@@ -1,7 +1,7 @@
-From 6627abe4c66533d3916a30a03f98daf560120a0f Mon Sep 17 00:00:00 2001
+From bc5d592e5820c6a949fabc196d81404bb824630f Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 20 Oct 2022 14:26:54 +0200
-Subject: [PATCH 2/2] x86/sev: Avoid using native_cpuid
+Subject: [PATCH 15/15] x86/sev: Avoid using native_cpuid
 
 In the state we get into the kernel from qboot-krunfw we can't return
 from #VC properly, so avoid calling native_cpuid in the early stages
@@ -12,14 +12,14 @@ enabled and the location of the cbit.
 
 Signed-off-by: Sergio Lopez <slp@redhat.com>
 ---
- arch/x86/mm/mem_encrypt_identity.c | 113 +++++++----------------------
- 1 file changed, 26 insertions(+), 87 deletions(-)
+ arch/x86/mm/mem_encrypt_identity.c | 114 +++++++----------------------
+ 1 file changed, 26 insertions(+), 88 deletions(-)
 
 diff --git a/arch/x86/mm/mem_encrypt_identity.c b/arch/x86/mm/mem_encrypt_identity.c
-index 88cccd65029d..471ebf438010 100644
+index c6efcf559d88..471ebf438010 100644
 --- a/arch/x86/mm/mem_encrypt_identity.c
 +++ b/arch/x86/mm/mem_encrypt_identity.c
-@@ -504,114 +504,53 @@ void __init sme_encrypt_kernel(struct boot_params *bp)
+@@ -504,115 +504,53 @@ void __init sme_encrypt_kernel(struct boot_params *bp)
  
  void __init sme_enable(struct boot_params *bp)
  {
@@ -144,7 +144,8 @@ index 88cccd65029d..471ebf438010 100644
 -	cmdline_ptr = (const char *)((u64)bp->hdr.cmd_line_ptr |
 -				     ((u64)bp->ext_cmd_line_ptr << 32));
 -
--	cmdline_find_option(cmdline_ptr, cmdline_arg, buffer, sizeof(buffer));
+-	if (cmdline_find_option(cmdline_ptr, cmdline_arg, buffer, sizeof(buffer)) < 0)
+-		return;
 -
 -	if (!strncmp(buffer, cmdline_on, sizeof(buffer)))
 -		sme_me_mask = me_mask;
@@ -161,5 +162,5 @@ index 88cccd65029d..471ebf438010 100644
  }
 +
 -- 
-2.39.0
+2.39.2
 

--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,4 +1,4 @@
-From 6cdbce21bba4a756ccb4b7e2ba199898543a24b5 Mon Sep 17 00:00:00 2001
+From df778bb2679379cb35d7d08179df16676a8fef6a Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 2 Mar 2023 07:34:49 +0100
 Subject: [PATCH 01/15] krunfw: Don't panic when init dies
@@ -16,7 +16,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 7 insertions(+)
 
 diff --git a/kernel/exit.c b/kernel/exit.c
-index 15dc2ec80c46..caf35fe8ff5d 100644
+index f2afdb0add7c..705bfdbb6124 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
 @@ -68,6 +68,7 @@
@@ -27,7 +27,7 @@ index 15dc2ec80c46..caf35fe8ff5d 100644
  
  #include <linux/uaccess.h>
  #include <asm/unistd.h>
-@@ -833,8 +834,12 @@ void __noreturn do_exit(long code)
+@@ -835,8 +836,12 @@ void __noreturn do_exit(long code)
  		 * immediately to get a useable coredump.
  		 */
  		if (unlikely(is_global_init(tsk)))
@@ -58,5 +58,5 @@ index 3bba88c7ffc6..a08a8a9b4d88 100644
  	machine_restart(cmd);
  }
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,4 +1,4 @@
-From 3a15e5dfa3dcae76b334d0010644af520ba2666d Mon Sep 17 00:00:00 2001
+From 3fd0df5d88d3f10a45dd309c09be923d33f08eb3 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
 Subject: [PATCH 02/15] krunfw: Ignore run_cmd on orderly reboot
@@ -28,5 +28,5 @@ index a08a8a9b4d88..838b7a293e43 100644
  	if (ret) {
  		pr_warn("Failed to start orderly reboot: forcing the issue\n");
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0003-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,4 +1,4 @@
-From 874ad1e79038e3888332a289993564f4be2affc8 Mon Sep 17 00:00:00 2001
+From 331696dfb23c11b1906bc26f4202d5c3294b5bfa Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Tue, 6 Apr 2021 23:22:06 +0000
 Subject: [PATCH 03/15] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
@@ -207,5 +207,5 @@ index ad64f403536a..3e157a62a9b1 100644
  
  static struct virtio_driver virtio_vsock_driver = {
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
+++ b/patches/0004-virtio-vsock-add-support-for-virtio-datagram.patch
@@ -1,4 +1,4 @@
-From 39c8fb37486e07684b806b6bac7ef591bc749bb6 Mon Sep 17 00:00:00 2001
+From b9710e9fbfd9375bbfa3c556cc9d85e77c91d5de Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:43:37 +0200
 Subject: [PATCH 04/15] virtio/vsock: add support for virtio datagram
@@ -954,5 +954,5 @@ index a9980e9b9304..06d4b89c597a 100644
  
  	/* Release refcnt obtained when we fetched this socket out of the
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
+++ b/patches/0005-vhost-vsock-add-support-for-vhost-dgram.patch
@@ -1,4 +1,4 @@
-From 92e3f99f86081bbc4c36ef726a551371c87e1082 Mon Sep 17 00:00:00 2001
+From 40a5baa7dbd9521b5ac2253d90962d4b98fe24df Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 10 Dec 2021 12:42:16 +0100
 Subject: [PATCH 05/15] vhost/vsock: add support for vhost dgram.
@@ -434,5 +434,5 @@ index c2353f2ac4e1..64fd52182ce8 100644
  		return ret;
  
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
+++ b/patches/0006-vsock_test-add-tests-for-vsock-dgram.patch
@@ -1,4 +1,4 @@
-From 673f31c7e600447681fb632b7c49827d536dbca3 Mon Sep 17 00:00:00 2001
+From 6234999f64582a4b9015192f3bbc8e27d33eb1c0 Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Fri, 9 Apr 2021 18:32:20 +0000
 Subject: [PATCH 06/15] vsock_test: add tests for vsock dgram
@@ -373,5 +373,5 @@ index bb6d691cb30d..c3003adda639 100644
  };
  
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
+++ b/patches/0007-virtio-vsock-add-sysfs-for-rx-buf-len-for-dgram.patch
@@ -1,4 +1,4 @@
-From d5aec35f074af2463e35db8f805b19fd7c1a1bdb Mon Sep 17 00:00:00 2001
+From 9684168326cde58f09e178ca6c20294622b21dba Mon Sep 17 00:00:00 2001
 From: Jiang Wang <jiang.wang@bytedance.com>
 Date: Thu, 26 May 2022 18:46:09 +0200
 Subject: [PATCH 07/15] virtio/vsock: add sysfs for rx buf len for dgram
@@ -97,5 +97,5 @@ index abaae264453b..5e78e9ca3e2b 100644
  
  module_init(virtio_vsock_init);
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
+++ b/patches/0008-virtio-vsock-Fix-DGRAM-polling.patch
@@ -1,4 +1,4 @@
-From a315169e2a45d4e6628593184bb9f3797589dcd6 Mon Sep 17 00:00:00 2001
+From ed69499bfaa9d8b444461850158c5acd3c8213e8 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:31:03 +0200
 Subject: [PATCH 08/15] virtio/vsock: Fix DGRAM polling
@@ -49,5 +49,5 @@ index 0fd3df91f52f..d4210968809b 100644
  		}
  
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
+++ b/patches/0009-virtio-vsock-add-DGRAM-to-virtio_transport_get_type.patch
@@ -1,4 +1,4 @@
-From acf7832d984064649ff03c5b2440c8eed85f15d4 Mon Sep 17 00:00:00 2001
+From efc884f6fe884e002e1037d43548a0711f8689ba Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:34:49 +0200
 Subject: [PATCH 09/15] virtio/vsock: add DGRAM to virtio_transport_get_type
@@ -27,5 +27,5 @@ index 06d4b89c597a..5e31e789b007 100644
  
  /* This function can only be used on connecting/connected sockets,
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -1,4 +1,4 @@
-From 96ad1b3abeae77a04cd16d559eee2abf716a740a Mon Sep 17 00:00:00 2001
+From 467ec769367a4b35a8cd790a24e61e5b860842a1 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
 Subject: [PATCH 10/15] Transparent Socket Impersonation implementation
@@ -81,7 +81,7 @@ index 6a62e5b27378..6e3d19c62528 100644
  obj-$(CONFIG_MCTP)		+= mctp/
 +obj-$(CONFIG_TSI)		+= tsi/
 diff --git a/net/socket.c b/net/socket.c
-index c12af3c84d3a..f4c821fac342 100644
+index b4cdc576afc3..2ae4f6eab56c 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -214,6 +214,7 @@ static const char * const pf_family_names[] = {
@@ -1510,5 +1510,5 @@ index 000000000000..cf381734bebe
 +
 +#endif
 -- 
-2.35.1
+2.39.2
 

--- a/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0011-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,4 +1,4 @@
-From ad50560b45673f182b882f3ac6426391d117cfe2 Mon Sep 17 00:00:00 2001
+From dc48dc6f33b5d84cf2b2ee2e1fcd69a4236ed7be Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
 Subject: [PATCH 11/15] tsi: allow hijacking sockets (tsi_hijack)
@@ -14,7 +14,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/net/socket.c b/net/socket.c
-index f4c821fac342..72c4c6db0349 100644
+index 2ae4f6eab56c..ec8b8100e3cc 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -112,6 +112,10 @@ unsigned int sysctl_net_busy_read __read_mostly;
@@ -28,7 +28,7 @@ index f4c821fac342..72c4c6db0349 100644
  static ssize_t sock_read_iter(struct kiocb *iocb, struct iov_iter *to);
  static ssize_t sock_write_iter(struct kiocb *iocb, struct iov_iter *from);
  static int sock_mmap(struct file *file, struct vm_area_struct *vma);
-@@ -1430,6 +1434,10 @@ int sock_wake_async(struct socket_wq *wq, int how, int band)
+@@ -1432,6 +1436,10 @@ int sock_wake_async(struct socket_wq *wq, int how, int band)
  }
  EXPORT_SYMBOL(sock_wake_async);
  
@@ -39,7 +39,7 @@ index f4c821fac342..72c4c6db0349 100644
  /**
   *	__sock_create - creates a socket
   *	@net: net namespace
-@@ -1500,6 +1508,15 @@ int __sock_create(struct net *net, int family, int type, int protocol,
+@@ -1502,6 +1510,15 @@ int __sock_create(struct net *net, int family, int type, int protocol,
  		request_module("net-pf-%d", family);
  #endif
  
@@ -69,5 +69,5 @@ index 38a383634ccd..91c9c5cb2285 100644
  	int err;
  
 -- 
-2.35.1
+2.39.2
 


### PR DESCRIPTION
Relatively small jump from 6.2.1 to 6.2.9. No significant changes required on the downstream patches.

Bump minor version to reflect the newer kernel, now at 3.11.0.

Update also initrd to pick up SNP support.