### PR TITLE
Force bundle alignment to 16K

### DIFF
--- a/bin2cbundle.py
+++ b/bin2cbundle.py
@@ -11,7 +11,7 @@ AARCH64_LOAD_ADDR = '0x80000000'
 
 def write_header(ofile, bundle_name):
     ofile.write('#include <stddef.h>\n')
-    ofile.write('__attribute__ ((aligned (4096))) char {}_BUNDLE[] = \n"'.format(bundle_name))
+    ofile.write('__attribute__ ((aligned (16384))) char {}_BUNDLE[] = \n"'.format(bundle_name))
 
 
 def write_padding(ofile, padding, col):


### PR DESCRIPTION
In addition to padding the size of the bundle to 16K, tell GCC to align its beginning to that value.

This should fix loading the bundle in Apple Silicon without causing any trouble to other environments.

Fixes: containers/libkrun#132