### PR TITLE
Add missing elftools to build-on-krunvm.sh

### DIFF
--- a/build_on_krunvm.sh
+++ b/build_on_krunvm.sh
@@ -18,9 +18,16 @@ if [ $? != 0 ]; then
 	exit -1
 fi
 
-krunvm start libkrunfw-builder /usr/bin/dnf -- install -y make gcc glibc-devel findutils xz patch flex bison diffutils bc perl cpio
+krunvm start libkrunfw-builder /usr/bin/dnf -- install -y 'dnf-command(builddep)' python3-pyelftools
 if [ $? != 0 ]; then
-	echo "Error running command on VM"
+	echo "Error installing dnf-builddep on VM"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/dnf -- builddep -y kernel
+if [ $? != 0 ]; then
+	echo "Error installing build dependencies for kernel"
 	krunvm delete libkrunfw-builder
 	exit -1
 fi


### PR DESCRIPTION
Running `./build_on_krunvm.sh`, the kernel build works fine, but fails near the end with

```
  OBJCOPY arch/arm64/boot/Image
  GZIP    arch/arm64/boot/Image.gz
make[1]: Leaving directory '/work/linux-6.1.32'
Generating kernel.c from linux-6.1.32/arch/arm64/boot/Image...
Traceback (most recent call last):
  File "/work/bin2cbundle.py", line 4, in <module>
    from elftools.elf.elffile import ELFFile
ModuleNotFoundError: No module named 'elftools'
```

There is a missing package `python3-pyelftools`.

Also replaced the explicit list of packages to install with an installation of `dnf builddep` and using the depedencies for the kernel package.

Fixes #52