### PR TITLE
Revert "config: Enable CONFIG_SECURITY_SELINUX"

### DIFF
--- a/config-libkrunfw-sev_x86_64
+++ b/config-libkrunfw-sev_x86_64
@@ -1806,7 +1806,7 @@ CONFIG_HAVE_HARDENED_USERCOPY_ALLOCATOR=y
 # CONFIG_HARDENED_USERCOPY is not set
 CONFIG_FORTIFY_SOURCE=y
 # CONFIG_STATIC_USERMODEHELPER is not set
-CONFIG_SECURITY_SELINUX=y
+# CONFIG_SECURITY_SELINUX is not set
 # CONFIG_SECURITY_SMACK is not set
 # CONFIG_SECURITY_TOMOYO is not set
 # CONFIG_SECURITY_APPARMOR is not set
@@ -1817,7 +1817,7 @@ CONFIG_SECURITY_SELINUX=y
 # CONFIG_SECURITY_LANDLOCK is not set
 # CONFIG_INTEGRITY is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,bpf"
+CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,bpf"
 
 #
 # Kernel hardening options

--- a/config-libkrunfw_aarch64
+++ b/config-libkrunfw_aarch64
@@ -2621,7 +2621,6 @@ CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_HARDENED_USERCOPY is not set
 # CONFIG_FORTIFY_SOURCE is not set
 # CONFIG_STATIC_USERMODEHELPER is not set
-CONFIG_SECURITY_SELINUX=y
 CONFIG_DEFAULT_SECURITY_DAC=y
 CONFIG_LSM="yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
 

--- a/config-libkrunfw_x86_64
+++ b/config-libkrunfw_x86_64
@@ -1812,7 +1812,7 @@ CONFIG_HAVE_HARDENED_USERCOPY_ALLOCATOR=y
 # CONFIG_HARDENED_USERCOPY is not set
 CONFIG_FORTIFY_SOURCE=y
 # CONFIG_STATIC_USERMODEHELPER is not set
-CONFIG_SECURITY_SELINUX=y
+# CONFIG_SECURITY_SELINUX is not set
 # CONFIG_SECURITY_SMACK is not set
 # CONFIG_SECURITY_TOMOYO is not set
 # CONFIG_SECURITY_APPARMOR is not set
@@ -1823,7 +1823,7 @@ CONFIG_SECURITY_SELINUX=y
 # CONFIG_SECURITY_LANDLOCK is not set
 # CONFIG_INTEGRITY is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,bpf"
+CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,bpf"
 
 #
 # Kernel hardening options

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -22,17 +22,15 @@ TODO - implement remote [get|set]sockopt
 
 Signed-off-by: Sergio Lopez <slp@redhat.com>
 ---
- include/linux/socket.h              |    4 +-
- net/Kconfig                         |    1 +
- net/Makefile                        |    1 +
- net/socket.c                        |    1 +
- net/tsi/Kconfig                     |    7 +
- net/tsi/Makefile                    |    4 +
- net/tsi/af_tsi.c                    | 1280 +++++++++++++++++++++++++++
- net/tsi/af_tsi.h                    |  100 +++
- security/selinux/hooks.c            |    2 +-
- security/selinux/include/classmap.h |    2 +-
- 10 files changed, 1399 insertions(+), 3 deletions(-)
+ include/linux/socket.h |    4 +-
+ net/Kconfig            |    1 +
+ net/Makefile           |    1 +
+ net/socket.c           |    1 +
+ net/tsi/Kconfig        |    7 +
+ net/tsi/Makefile       |    4 +
+ net/tsi/af_tsi.c       | 1280 ++++++++++++++++++++++++++++++++++++++++
+ net/tsi/af_tsi.h       |  100 ++++
+ 8 files changed, 1397 insertions(+), 1 deletion(-)
  create mode 100644 net/tsi/Kconfig
  create mode 100644 net/tsi/Makefile
  create mode 100644 net/tsi/af_tsi.c
@@ -1509,31 +1507,6 @@ index 000000000000..cf381734bebe
 +} __attribute__((packed));
 +
 +#endif
-diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
-index 53cfeefb2f19..428801687e5c 100644
---- a/security/selinux/hooks.c
-+++ b/security/selinux/hooks.c
-@@ -1295,7 +1295,7 @@ static inline u16 socket_type_to_security_class(int family, int type, int protoc
- 			return SECCLASS_XDP_SOCKET;
- 		case PF_MCTP:
- 			return SECCLASS_MCTP_SOCKET;
--#if PF_MAX > 46
-+#if PF_MAX > 47
- #error New address family defined, please update this function.
- #endif
- 		}
-diff --git a/security/selinux/include/classmap.h b/security/selinux/include/classmap.h
-index a3c380775d41..06cb017611f8 100644
---- a/security/selinux/include/classmap.h
-+++ b/security/selinux/include/classmap.h
-@@ -259,6 +259,6 @@ const struct security_class_mapping secclass_map[] = {
- 	{ NULL }
-   };
- 
--#if PF_MAX > 46
-+#if PF_MAX > 47
- #error New address family defined, please update secclass_map.
- #endif
 -- 
 2.43.0
 


### PR DESCRIPTION
This reverts commit ce7277c0504b6f2f0c369b2adb11e86f18ab6e57.

SELinux was enabled for crun-vm's [1] use case of running bootc-install, but the dependency on SELinux was since dropped.

Re-disable SELinux to avoid bloat. This has no effect on the x86_64 image since its defconfig includes CONFIG_SECURITY_SELINUX=y, but it should help reduce the aarch64 image size.

[1] https://github.com/containers/crun-vm