### PR TITLE
config: Enable CONFIG_SECURITY_SELINUX

### DIFF
--- a/config-libkrunfw-sev_x86_64
+++ b/config-libkrunfw-sev_x86_64
@@ -2031,7 +2031,7 @@ CONFIG_SECURITY_NETWORK_XFRM=y
 # CONFIG_HARDENED_USERCOPY is not set
 CONFIG_FORTIFY_SOURCE=y
 # CONFIG_STATIC_USERMODEHELPER is not set
-# CONFIG_SECURITY_SELINUX is not set
+CONFIG_SECURITY_SELINUX=y
 # CONFIG_SECURITY_SMACK is not set
 # CONFIG_SECURITY_TOMOYO is not set
 # CONFIG_SECURITY_APPARMOR is not set
@@ -2043,7 +2043,7 @@ CONFIG_FORTIFY_SOURCE=y
 # CONFIG_INTEGRITY is not set
 # CONFIG_IMA_SECURE_AND_OR_TRUSTED_BOOT is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,bpf"
+CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,bpf"
 
 #
 # Kernel hardening options

--- a/config-libkrunfw_aarch64
+++ b/config-libkrunfw_aarch64
@@ -2622,6 +2622,7 @@ CONFIG_KEY_DH_OPERATIONS=y
 # CONFIG_HARDENED_USERCOPY is not set
 # CONFIG_FORTIFY_SOURCE is not set
 # CONFIG_STATIC_USERMODEHELPER is not set
+CONFIG_SECURITY_SELINUX=y
 CONFIG_DEFAULT_SECURITY_DAC=y
 CONFIG_LSM="yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
 

--- a/config-libkrunfw_x86_64
+++ b/config-libkrunfw_x86_64
@@ -1813,7 +1813,7 @@ CONFIG_HAVE_HARDENED_USERCOPY_ALLOCATOR=y
 # CONFIG_HARDENED_USERCOPY is not set
 CONFIG_FORTIFY_SOURCE=y
 # CONFIG_STATIC_USERMODEHELPER is not set
-# CONFIG_SECURITY_SELINUX is not set
+CONFIG_SECURITY_SELINUX=y
 # CONFIG_SECURITY_SMACK is not set
 # CONFIG_SECURITY_TOMOYO is not set
 # CONFIG_SECURITY_APPARMOR is not set
@@ -1824,7 +1824,7 @@ CONFIG_FORTIFY_SOURCE=y
 # CONFIG_SECURITY_LANDLOCK is not set
 # CONFIG_INTEGRITY is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,bpf"
+CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,bpf"
 
 #
 # Kernel hardening options

--- a/patches/0010-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0010-Transparent-Socket-Impersonation-implementation.patch
@@ -22,15 +22,17 @@ TODO - implement remote [get|set]sockopt
 
 Signed-off-by: Sergio Lopez <slp@redhat.com>
 ---
- include/linux/socket.h |    4 +-
- net/Kconfig            |    1 +
- net/Makefile           |    1 +
- net/socket.c           |    1 +
- net/tsi/Kconfig        |    7 +
- net/tsi/Makefile       |    4 +
- net/tsi/af_tsi.c       | 1280 ++++++++++++++++++++++++++++++++++++++++
- net/tsi/af_tsi.h       |  100 ++++
- 8 files changed, 1397 insertions(+), 1 deletion(-)
+ include/linux/socket.h              |    4 +-
+ net/Kconfig                         |    1 +
+ net/Makefile                        |    1 +
+ net/socket.c                        |    1 +
+ net/tsi/Kconfig                     |    7 +
+ net/tsi/Makefile                    |    4 +
+ net/tsi/af_tsi.c                    | 1280 +++++++++++++++++++++++++++
+ net/tsi/af_tsi.h                    |  100 +++
+ security/selinux/hooks.c            |    2 +-
+ security/selinux/include/classmap.h |    2 +-
+ 10 files changed, 1399 insertions(+), 3 deletions(-)
  create mode 100644 net/tsi/Kconfig
  create mode 100644 net/tsi/Makefile
  create mode 100644 net/tsi/af_tsi.c
@@ -1507,6 +1509,31 @@ index 000000000000..cf381734bebe
 +} __attribute__((packed));
 +
 +#endif
+diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
+index 53cfeefb2f19..428801687e5c 100644
+--- a/security/selinux/hooks.c
++++ b/security/selinux/hooks.c
+@@ -1295,7 +1295,7 @@ static inline u16 socket_type_to_security_class(int family, int type, int protoc
+ 			return SECCLASS_XDP_SOCKET;
+ 		case PF_MCTP:
+ 			return SECCLASS_MCTP_SOCKET;
+-#if PF_MAX > 46
++#if PF_MAX > 47
+ #error New address family defined, please update this function.
+ #endif
+ 		}
+diff --git a/security/selinux/include/classmap.h b/security/selinux/include/classmap.h
+index a3c380775d41..06cb017611f8 100644
+--- a/security/selinux/include/classmap.h
++++ b/security/selinux/include/classmap.h
+@@ -259,6 +259,6 @@ const struct security_class_mapping secclass_map[] = {
+ 	{ NULL }
+   };
+ 
+-#if PF_MAX > 46
++#if PF_MAX > 47
+ #error New address family defined, please update secclass_map.
+ #endif
 -- 
 2.45.1
 


### PR DESCRIPTION
As discussed offline, many workloads assume SELinux support. (Re)enable SELinux support.