### PR TITLE
patches: Add virtgpu map fixes.

### DIFF
--- a/patches/0021-virtgpu-gem-partial-map.patch
+++ b/patches/0021-virtgpu-gem-partial-map.patch
@@ -1,0 +1,35 @@
+From: Sasha Finkelstein <fnkl.kernel@gmail.com>
+
+Those are useful to implement coherent cross-vm mmap.
+
+Signed-off-by: Sasha Finkelstein <fnkl.kernel@gmail.com>
+---
+ drivers/gpu/drm/virtio/virtgpu_vram.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_vram.c b/drivers/gpu/drm/virtio/virtgpu_vram.c
+index 25df81c027837c248a746e41856b5aa7e216b8d5..64e2c6dbdd678ac4c0da89fdd4c9dbf937c2c335 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_vram.c
++++ b/drivers/gpu/drm/virtio/virtgpu_vram.c
+@@ -56,12 +56,11 @@ static int virtio_gpu_vram_mmap(struct drm_gem_object *obj,
+ 	else if (vram->map_info == VIRTIO_GPU_MAP_CACHE_UNCACHED)
+ 		vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+ 
+-	/* Partial mappings of GEM buffers don't happen much in practice. */
+-	if (vm_size != vram->vram_node.size)
++	if (vm_size > vram->vram_node.size)
+ 		return -EINVAL;
+ 
+ 	ret = io_remap_pfn_range(vma, vma->vm_start,
+-				 vram->vram_node.start >> PAGE_SHIFT,
++				 (vram->vram_node.start >> PAGE_SHIFT) + vma->vm_pgoff,
+ 				 vm_size, vma->vm_page_prot);
+ 	return ret;
+ }
+
+---
+base-commit: 643e2e259c2b25a2af0ae4c23c6e16586d9fd19c
+change-id: 20250109-virtgpu-gem-partial-map-335ec40656d1
+
+
+

--- a/patches/0022-virtgpu-mixed-page-size.patch
+++ b/patches/0022-virtgpu-mixed-page-size.patch
@@ -1,0 +1,45 @@
+From: Sasha Finkelstein <fnkl.kernel@gmail.com>
+
+This allows running different page sizes between host and guest on
+platforms that support mixed page sizes.
+
+Signed-off-by: Sasha Finkelstein <fnkl.kernel@gmail.com>
+---
+ drivers/gpu/drm/virtio/virtgpu_vram.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_vram.c b/drivers/gpu/drm/virtio/virtgpu_vram.c
+index 25df81c027837c248a746e41856b5aa7e216b8d5..8a0577c2170ec9c12cad12be57f9a41c14f04660 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_vram.c
++++ b/drivers/gpu/drm/virtio/virtgpu_vram.c
+@@ -138,6 +138,12 @@ bool virtio_gpu_is_vram(struct virtio_gpu_object *bo)
+ 	return bo->base.base.funcs == &virtio_gpu_vram_funcs;
+ }
+ 
++#if defined(__powerpc64__) || defined(__aarch64__) || defined(__mips__) || defined(__loongarch__)
++#define MAX_PAGE_SIZE 65536
++#else
++#define MAX_PAGE_SIZE PAGE_SIZE
++#endif
++
+ static int virtio_gpu_vram_map(struct virtio_gpu_object *bo)
+ {
+ 	int ret;
+@@ -150,8 +156,8 @@ static int virtio_gpu_vram_map(struct virtio_gpu_object *bo)
+ 		return -EINVAL;
+ 
+ 	spin_lock(&vgdev->host_visible_lock);
+-	ret = drm_mm_insert_node(&vgdev->host_visible_mm, &vram->vram_node,
+-				 bo->base.base.size);
++	ret = drm_mm_insert_node_generic(&vgdev->host_visible_mm, &vram->vram_node,
++					 bo->base.base.size, MAX_PAGE_SIZE, 0, 0);
+ 	spin_unlock(&vgdev->host_visible_lock);
+ 
+ 	if (ret)
+
+---
+base-commit: 643e2e259c2b25a2af0ae4c23c6e16586d9fd19c
+change-id: 20250109-virtgpu-mixed-page-size-282b8f4a02fc
+
+
+


### PR DESCRIPTION
This forces host mmaps to be aligned to maximum platform page size, and allows partial maps of gem objects. Both are needed for pipewire passthrough

Patch sources:
https://lore.kernel.org/lkml/20250109-virtgpu-gem-partial-map-v1-1-a914b48776bd@gmail.com/T/#u
https://lore.kernel.org/lkml/20250109-virtgpu-mixed-page-size-v1-1-c8fe1e1859f3@gmail.com/T/#u
