### PR TITLE
Add krunvm debian environment for macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ This will create a lightweight Linux VM using ```krunvm``` with the current work
 make
 ```
 
+By default, the build environment is based on a Fedora image. There is also a Debian variant which can be selected by setting the `BUILDER` environment variable.
+
+```
+BUILDER=debian ./build_on_krunvm.sh
+```
+
+In general, `./build_on_krunvm.sh` will always delegate to `./build_on_krunvm_${BUILDER}.sh` so additional environments can be added like this if needed.
+
 ## Known limitations
 
 * To save memory, the embedded kernel is configured with ```CONFIG_NR_CPUS=8```, which limits the maximum number of supported CPUs to 8. If this kernel runs in a VM with more CPUs, only the first 8 will be initialized and used.

--- a/build_on_krunvm.sh
+++ b/build_on_krunvm.sh
@@ -3,47 +3,9 @@
 # This is a helper script for building the Linux kernel on macOS using
 # a lightweight VM with krunvm.
 
-KRUNVM=`which krunvm`
-if [ -z "$KRUNVM" ]; then
-	echo "Couldn't find krunvm binary"
-	exit -1
-fi
+: "${BUILDER:=fedora}"
 
-# realpath does not exist by default on macOS, use `brew install coreutils` to get it
 SCRIPTPATH=`realpath $0`
 WORKDIR=`dirname $SCRIPTPATH`
-krunvm create fedora --name libkrunfw-builder --cpus 2 --mem 2048 -v $WORKDIR:/work -w /work
-if [ $? != 0 ]; then
-	echo "Error creating lightweight VM"
-	exit -1
-fi
 
-krunvm start libkrunfw-builder /usr/bin/dnf -- install -y 'dnf-command(builddep)' python3-pyelftools
-if [ $? != 0 ]; then
-	echo "Error installing dnf-builddep on VM"
-	krunvm delete libkrunfw-builder
-	exit -1
-fi
-
-krunvm start libkrunfw-builder /usr/bin/dnf -- builddep -y kernel
-if [ $? != 0 ]; then
-	echo "Error installing build dependencies for kernel"
-	krunvm delete libkrunfw-builder
-	exit -1
-fi
-
-krunvm start libkrunfw-builder /usr/bin/make -- -j2
-if [ $? != 0 ]; then
-	echo "Error running command on VM"
-	krunvm delete libkrunfw-builder
-	exit -1
-fi
-
-krunvm delete libkrunfw-builder
-
-if [ ! -e "kernel.c" ]; then
-	echo "There was a problem building the kernel bundle in the VM"
-	exit -1
-fi
-
-exit 0
+$WORKDIR/build_on_krunvm_${BUILDER}.sh

--- a/build_on_krunvm_debian.sh
+++ b/build_on_krunvm_debian.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# This is a helper script for building the Linux kernel on macOS using
+# a lightweight VM with krunvm.
+
+KRUNVM=`which krunvm`
+if [ -z "$KRUNVM" ]; then
+	echo "Couldn't find krunvm binary"
+	exit -1
+fi
+
+# realpath does not exist by default on macOS, use `brew install coreutils` to get it
+SCRIPTPATH=`realpath $0`
+WORKDIR=`dirname $SCRIPTPATH`
+krunvm create debian:bookworm-slim --name libkrunfw-builder --cpus 2 --mem 2048 -v $WORKDIR:/work -w /work
+if [ $? != 0 ]; then
+	echo "Error creating lightweight VM"
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/apt-get -- update
+if [ $? != 0 ]; then
+	echo "Error updating debian repository"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/apt-get -- upgrade -y
+if [ $? != 0 ]; then
+	echo "Error upgrading debian packages"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/apt-get -- install -y curl build-essential python3-pyelftools bc kmod cpio flex libncurses5-dev libelf-dev libssl-dev dwarves bison
+if [ $? != 0 ]; then
+	echo "Error installing build dependencies on VM"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/make -- -j2
+if [ $? != 0 ]; then
+	echo "Error running command on VM"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm delete libkrunfw-builder
+
+if [ ! -e "kernel.c" ]; then
+	echo "There was a problem building the kernel bundle in the VM"
+	exit -1
+fi
+
+exit 0

--- a/build_on_krunvm_fedora.sh
+++ b/build_on_krunvm_fedora.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# This is a helper script for building the Linux kernel on macOS using
+# a lightweight VM with krunvm.
+
+KRUNVM=`which krunvm`
+if [ -z "$KRUNVM" ]; then
+	echo "Couldn't find krunvm binary"
+	exit -1
+fi
+
+# realpath does not exist by default on macOS, use `brew install coreutils` to get it
+SCRIPTPATH=`realpath $0`
+WORKDIR=`dirname $SCRIPTPATH`
+krunvm create fedora --name libkrunfw-builder --cpus 2 --mem 2048 -v $WORKDIR:/work -w /work
+if [ $? != 0 ]; then
+	echo "Error creating lightweight VM"
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/dnf -- install -y 'dnf-command(builddep)' python3-pyelftools
+if [ $? != 0 ]; then
+	echo "Error installing dnf-builddep on VM"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/dnf -- builddep -y kernel
+if [ $? != 0 ]; then
+	echo "Error installing build dependencies for kernel"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm start libkrunfw-builder /usr/bin/make -- -j2
+if [ $? != 0 ]; then
+	echo "Error running command on VM"
+	krunvm delete libkrunfw-builder
+	exit -1
+fi
+
+krunvm delete libkrunfw-builder
+
+if [ ! -e "kernel.c" ]; then
+	echo "There was a problem building the kernel bundle in the VM"
+	exit -1
+fi
+
+exit 0


### PR DESCRIPTION
The default image used for linux kernel build on macOS contains numerous unrelated packages which make the initial dnf upgrade unnecessarily long. I added option to use the debian slim image instead.