### PR TITLE
Update init binary and add TDX kernel build to CI

### DIFF
--- a/.github/workflows/build-tdx.yml
+++ b/.github/workflows/build-tdx.yml
@@ -1,0 +1,23 @@
+name: Build TDX kernel
+on: [pull_request, create]
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    name: Build TDX kernel
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: sudo apt-get install -y make gcc bc bison flex elfutils python3-pyelftools curl patch libelf-dev
+
+      - name: Build TDX kernel
+        run: make TDX=1


### PR DESCRIPTION
Updates the init binary bundle to include a binary that does not do attestation when using the libkrun flavor. Built based on the work in this PR: https://github.com/containers/libkrun/pull/355 

Additionally adds a CI workflow to build the TDX kernel.