### PR TITLE
tsi: fix tsi_create and hijack AF_INET6

### DIFF
--- a/patches-tee/0001-virtio-enable-DMA-API-if-memory-is-restricted.patch
+++ b/patches-tee/0001-virtio-enable-DMA-API-if-memory-is-restricted.patch
@@ -1,4 +1,4 @@
-From ef2cfc3794002ecf53cdb4e1b90bc73d13d02064 Mon Sep 17 00:00:00 2001
+From 2e8e1863e5efc6d344adfbb61318210152534f36 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@sinrega.org>
 Date: Fri, 10 Sep 2021 13:05:01 +0200
 Subject: [PATCH 1/4] virtio: enable DMA API if memory is restricted

--- a/patches-tee/0002-x86-sev-write-AP-reset-vector.patch
+++ b/patches-tee/0002-x86-sev-write-AP-reset-vector.patch
@@ -1,4 +1,4 @@
-From 58bcedac702edc08536b1afd6063f39294088a8f Mon Sep 17 00:00:00 2001
+From c605b5cf9b990e649421c6d3aafc6736ff1c06a0 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 20 Oct 2022 10:23:16 +0200
 Subject: [PATCH 2/4] x86/sev: write AP reset vector

--- a/patches-tee/0003-Implement-driver-to-retrieve-secrets-from-cmdline.patch
+++ b/patches-tee/0003-Implement-driver-to-retrieve-secrets-from-cmdline.patch
@@ -1,4 +1,4 @@
-From ea26a05d3f8307b9e07c280a118190fe9051dc1d Mon Sep 17 00:00:00 2001
+From 658ffe8e52851fcb61c67cf3a8e32dd507e70762 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Wed, 3 Aug 2022 12:35:12 +0200
 Subject: [PATCH 3/4] Implement driver to retrieve secrets from cmdline

--- a/patches-tee/0004-x86-sev-Avoid-using-native_cpuid.patch
+++ b/patches-tee/0004-x86-sev-Avoid-using-native_cpuid.patch
@@ -1,4 +1,4 @@
-From 0c4fbdf990f683a32d3be782c763e043c2f1799b Mon Sep 17 00:00:00 2001
+From 6120f12e56114be4afda0906bd091d8692eafe1e Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Wed, 5 Jun 2024 16:20:08 +0200
 Subject: [PATCH 4/4] x86/sev: Avoid using native_cpuid

--- a/patches/0009-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0009-Transparent-Socket-Impersonation-implementation.patch
@@ -1,4 +1,4 @@
-From 8b6e0c7550ba7f4c11e6df61c48ed0783dc38513 Mon Sep 17 00:00:00 2001
+From a2e77e858d438a0f1d787122252cbd60d5a2297e Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
 Subject: [PATCH 09/21] Transparent Socket Impersonation implementation
@@ -119,7 +119,7 @@ index 000000000000..8b3cf74116a5
 +tsi-y := af_tsi.o
 diff --git a/net/tsi/af_tsi.c b/net/tsi/af_tsi.c
 new file mode 100644
-index 000000000000..f43a17cff3a3
+index 000000000000..7c9e4dc1a114
 --- /dev/null
 +++ b/net/tsi/af_tsi.c
 @@ -0,0 +1,1280 @@
@@ -1317,24 +1317,24 @@ index 000000000000..f43a17cff3a3
 +	err = __sock_create(current->nsproxy->net_ns, PF_INET,
 +			    sock->type, protocol, &isocket, 1);
 +	if (err) {
-+		pr_err("%s (%d): problem creating inet socket\n",
-+		       __func__, task_pid_nr(current));
-+		goto release_isocket;
++		pr_debug("%s (%d): problem creating inet socket\n",
++		         __func__, task_pid_nr(current));
++		return err;
 +	}
 +
 +	vsocket = NULL;
 +	err = __sock_create(current->nsproxy->net_ns, PF_VSOCK,
 +			    sock->type, PF_VSOCK, &vsocket, 1);
 +	if (err) {
-+		pr_err("%s (%d): problem creating vsock socket\n",
-+		       __func__, task_pid_nr(current));
-+		goto release_vsocket;
++		pr_debug("%s (%d): problem creating vsock socket\n",
++		         __func__, task_pid_nr(current));
++		goto release_isocket;
 +	}
 +
 +	err = tsi_create_control_socket(&csocket);
 +	if (err) {
-+		pr_err("%s (%d): problem creating control socket\n",
-+		       __func__, task_pid_nr(current));
++		pr_debug("%s (%d): problem creating control socket\n",
++		         __func__, task_pid_nr(current));
 +		goto release_vsocket;
 +	}
 +

--- a/patches/0010-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0010-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,4 +1,4 @@
-From 0935e6b153ffeecfbe5509971805ad2bf5b53bb0 Mon Sep 17 00:00:00 2001
+From 9b38a09718d4a95890ad295c231209d62a21ceb3 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
 Subject: [PATCH 10/21] tsi: allow hijacking sockets (tsi_hijack)
@@ -9,12 +9,12 @@ sockets to turn them into TSI sockets.
 
 Signed-off-by: Sergio Lopez <slp@redhat.com>
 ---
- net/socket.c     | 17 +++++++++++++++++
+ net/socket.c     | 18 ++++++++++++++++++
  net/tsi/af_tsi.c |  2 +-
- 2 files changed, 18 insertions(+), 1 deletion(-)
+ 2 files changed, 19 insertions(+), 1 deletion(-)
 
 diff --git a/net/socket.c b/net/socket.c
-index 5ad75d15e1ad..bf8818423454 100644
+index 5ad75d15e1ad..03c79066a8e9 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -115,6 +115,10 @@ unsigned int sysctl_net_busy_read __read_mostly;
@@ -39,12 +39,13 @@ index 5ad75d15e1ad..bf8818423454 100644
  /**
   *	__sock_create - creates a socket
   *	@net: net namespace
-@@ -1558,6 +1566,15 @@ int __sock_create(struct net *net, int family, int type, int protocol,
+@@ -1558,6 +1566,16 @@ int __sock_create(struct net *net, int family, int type, int protocol,
  		request_module("net-pf-%d", family);
  #endif
  
 +#ifdef CONFIG_TSI
-+	if (tsi_hijack && !kern && family == AF_INET &&
++	if (tsi_hijack && !kern &&
++	    (family == AF_INET || family == AF_INET6) &&
 +	    (type == SOCK_STREAM || type == SOCK_DGRAM)) {
 +		pr_debug("%s - tsi: hijacking AF_INET socket\n",
 +			current->comm);
@@ -56,7 +57,7 @@ index 5ad75d15e1ad..bf8818423454 100644
  	pf = rcu_dereference(net_families[family]);
  	err = -EAFNOSUPPORT;
 diff --git a/net/tsi/af_tsi.c b/net/tsi/af_tsi.c
-index f43a17cff3a3..ef1552862253 100644
+index 7c9e4dc1a114..a1d167a8787e 100644
 --- a/net/tsi/af_tsi.c
 +++ b/net/tsi/af_tsi.c
 @@ -474,7 +474,7 @@ static int tsi_accept(struct socket *sock, struct socket *newsock,

--- a/patches/0011-arm64-cpufeature-Unify-SCOPE_LOCAL_CPU-early-late-be.patch
+++ b/patches/0011-arm64-cpufeature-Unify-SCOPE_LOCAL_CPU-early-late-be.patch
@@ -1,4 +1,4 @@
-From c8e1af2aa98011bbfd90f95d3a05b22a5bb48413 Mon Sep 17 00:00:00 2001
+From 98d3b2be1298caecc612cd9efb33cc1f5c8c741e Mon Sep 17 00:00:00 2001
 From: Asahi Lina <lina@asahilina.net>
 Date: Wed, 25 Sep 2024 16:35:34 +0200
 Subject: [PATCH 11/21] arm64: cpufeature: Unify SCOPE_LOCAL_CPU early & late

--- a/patches/0012-prctl-Introduce-PR_-SET-GET-_MEM_MODEL.patch
+++ b/patches/0012-prctl-Introduce-PR_-SET-GET-_MEM_MODEL.patch
@@ -1,4 +1,4 @@
-From b81a57520d253fd95e3263326560bdc8d0b6979a Mon Sep 17 00:00:00 2001
+From 50e73e54bac3bd57fba7ee616ae06632b6c9c2da Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:20 +0900
 Subject: [PATCH 12/21] prctl: Introduce PR_{SET,GET}_MEM_MODEL

--- a/patches/0013-arm64-Implement-PR_-GET-SET-_MEM_MODEL-for-always-TS.patch
+++ b/patches/0013-arm64-Implement-PR_-GET-SET-_MEM_MODEL-for-always-TS.patch
@@ -1,4 +1,4 @@
-From a93aea056017c8d117a3e585cfcc47f68d8e4230 Mon Sep 17 00:00:00 2001
+From f1334c8e646bdb63b33de190038276ba4442dc32 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:21 +0900
 Subject: [PATCH 13/21] arm64: Implement PR_{GET,SET}_MEM_MODEL for always-TSO

--- a/patches/0014-arm64-Introduce-scaffolding-to-add-ACTLR_EL1-to-thre.patch
+++ b/patches/0014-arm64-Introduce-scaffolding-to-add-ACTLR_EL1-to-thre.patch
@@ -1,4 +1,4 @@
-From 149bf1c274f3bbe3676e2c5eaf374376934610d2 Mon Sep 17 00:00:00 2001
+From c678ff72878c15e26a9e3ce7c9895e12f46d531b Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:22 +0900
 Subject: [PATCH 14/21] arm64: Introduce scaffolding to add ACTLR_EL1 to thread

--- a/patches/0015-arm64-Implement-Apple-IMPDEF-TSO-memory-model-contro.patch
+++ b/patches/0015-arm64-Implement-Apple-IMPDEF-TSO-memory-model-contro.patch
@@ -1,4 +1,4 @@
-From fd5d74a42bdfa7a86ad0610b3f02f2878edd7328 Mon Sep 17 00:00:00 2001
+From ddc9185324167fbf26f4d7f5bb2c215c700a06a3 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:23 +0900
 Subject: [PATCH 15/21] arm64: Implement Apple IMPDEF TSO memory model control

--- a/patches/0016-drm-virtio-Support-fence-passing-feature.patch
+++ b/patches/0016-drm-virtio-Support-fence-passing-feature.patch
@@ -1,4 +1,4 @@
-From ebd3c2a53a71c41992c78810ea544dbccb30ecf0 Mon Sep 17 00:00:00 2001
+From cea03bcb3cc991a5e4b1c554718040c78db34c4b Mon Sep 17 00:00:00 2001
 From: Dmitry Osipenko <dmitry.osipenko@collabora.com>
 Date: Sat, 7 Oct 2023 22:47:47 +0300
 Subject: [PATCH 16/21] drm/virtio: Support fence-passing feature

--- a/patches/0017-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
+++ b/patches/0017-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
@@ -1,4 +1,4 @@
-From fd8848267f45786240285fb77d565a15287c87c4 Mon Sep 17 00:00:00 2001
+From 745d1eee466a231841f9265a5075b319be62b4e8 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Tue, 8 Oct 2024 11:24:25 +0200
 Subject: [PATCH 17/21] Enable 64 bit processes to use compat input syscalls

--- a/patches/0018-dax-Allow-block-size-PAGE_SIZE.patch
+++ b/patches/0018-dax-Allow-block-size-PAGE_SIZE.patch
@@ -1,4 +1,4 @@
-From 0e6c03a77f8173d5e78c991518a29b2f57ac326f Mon Sep 17 00:00:00 2001
+From 2e9b9a7bb452303f3f00b4f6ae34fe89ffdecf5a Mon Sep 17 00:00:00 2001
 From: Asahi Lina <lina@asahilina.net>
 Date: Sun, 20 Oct 2024 01:23:41 +0900
 Subject: [PATCH 18/21] dax: Allow block size > PAGE_SIZE

--- a/patches/0019-mm-Fix-__wp_page_copy_user-fallback-path-for-remote-.patch
+++ b/patches/0019-mm-Fix-__wp_page_copy_user-fallback-path-for-remote-.patch
@@ -1,4 +1,4 @@
-From 7e72713fe4839e6c65a8106faec3fafc08d7cf27 Mon Sep 17 00:00:00 2001
+From e7b549f447fda1e4a2fd3d215a937f9082fffd1f Mon Sep 17 00:00:00 2001
 From: Asahi Lina <lina@asahilina.net>
 Date: Mon, 21 Oct 2024 23:21:16 +0900
 Subject: [PATCH 19/21] mm: Fix __wp_page_copy_user fallback path for remote mm

--- a/patches/0020-virtgpu-gem-partial-map.patch
+++ b/patches/0020-virtgpu-gem-partial-map.patch
@@ -1,4 +1,4 @@
-From 7ae820e1cbaee74a117ada694e8f086a60d1a6f3 Mon Sep 17 00:00:00 2001
+From 3203070536bb1a264b500a3f8e2ed3bf1f205645 Mon Sep 17 00:00:00 2001
 From: Sasha Finkelstein <fnkl.kernel@gmail.com>
 Date: Fri, 17 Jan 2025 12:34:23 +0100
 Subject: [PATCH 20/21] virtgpu: gem partial map

--- a/patches/0021-virtgpu-mixed-page-size.patch
+++ b/patches/0021-virtgpu-mixed-page-size.patch
@@ -1,4 +1,4 @@
-From 33660252a2047558bbd2d4445db3a7115b4f20d9 Mon Sep 17 00:00:00 2001
+From 5e2152c80d146e0f960b454161757eb680452fae Mon Sep 17 00:00:00 2001
 From: Sasha Finkelstein <fnkl.kernel@gmail.com>
 Date: Fri, 17 Jan 2025 12:34:28 +0100
 Subject: [PATCH 21/21] virtgpu: mixed page size


### PR DESCRIPTION
Fix an issue where tsi_create may attempt to exit releasing sockets that hasn't been allocated.

While there, make "tsi_hijack" also hijack AF_INET6 sockets. Some applications (like ones built with recent Go libraries) attempt to bind to AF_INET6 sockets only, relying on the kernel's ability to bind on AF_INET transparently. For TSI, this means those sockets won't be hijacked and exposed to the host.

By hijacking AF_INET6 sockets, the application receives EAFNOSUPPORT when binding the socket, leading to it attempting again to bind using AF_INET.

Fixes: #99