### PR TITLE
config: consistently enable TUN and VETH across arches

### DIFF
--- a/config-libkrunfw_aarch64
+++ b/config-libkrunfw_aarch64
@@ -1398,9 +1398,9 @@ CONFIG_NET_CORE=y
 # CONFIG_GTP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=y
 # CONFIG_TUN_VNET_CROSS_LE is not set
-# CONFIG_VETH is not set
+CONFIG_VETH=y
 CONFIG_VIRTIO_NET=y
 # CONFIG_NLMON is not set
 # CONFIG_MHI_NET is not set

--- a/config-libkrunfw_riscv64
+++ b/config-libkrunfw_riscv64
@@ -1264,9 +1264,9 @@ CONFIG_NET_CORE=y
 # CONFIG_PFCP is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=y
 # CONFIG_TUN_VNET_CROSS_LE is not set
-# CONFIG_VETH is not set
+CONFIG_VETH=y
 CONFIG_VIRTIO_NET=y
 # CONFIG_NLMON is not set
 # CONFIG_NETKIT is not set


### PR DESCRIPTION
They're already enabled on x86_64, enable on other architectures as well. TUN is especially useful for VPN clients.

---

Discussion: Would be great for us if NF_TABLES (with very basic modules like conntrack/counter/..) were also enabled, would that be too much of a space increase?

For some background: for [Clan](https://clan.lol/) we're working on an app platform where peer-to-peer apps could be shipped as microVMs pre-connected to a mesh VPN / overlay network, aiming to support various VPN solutions. While some like ZeroTier are perfectly happy with just a TUN interface, others like Tailscale have a hard requirement on being able to configure nftables.