### PR TITLE
tsi: forward protocol field in proxy create enabling DGRAM+ICMP ping

### DIFF
--- a/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
+++ b/patches/0001-krunfw-Don-t-panic-when-init-dies.patch
@@ -1,4 +1,4 @@
-From 10ae66b1024db238899ccce1f790620ab5c92aa9 Mon Sep 17 00:00:00 2001
+From c4ab89d5afe0b5b710aeb7a15055fa77d5903b7c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 2 Mar 2023 07:34:49 +0100
 Subject: [PATCH 01/30] krunfw: Don't panic when init dies
@@ -16,7 +16,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 8 insertions(+)
 
 diff --git a/kernel/exit.c b/kernel/exit.c
-index b91124b2d334..b78ea85c953a 100644
+index b91124b..b78ea85 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
 @@ -69,6 +69,8 @@
@@ -42,7 +42,7 @@ index b91124b2d334..b78ea85c953a 100644
  #ifdef CONFIG_POSIX_TIMERS
  		hrtimer_cancel(&tsk->signal->real_timer);
 diff --git a/kernel/reboot.c b/kernel/reboot.c
-index d6ee090eda94..f6947c5bd671 100644
+index d6ee090..f6947c5 100644
 --- a/kernel/reboot.c
 +++ b/kernel/reboot.c
 @@ -278,10 +278,12 @@ void kernel_restart(char *cmd)

--- a/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
+++ b/patches/0002-krunfw-Ignore-run_cmd-on-orderly-reboot.patch
@@ -1,4 +1,4 @@
-From 41ad056fb2d1e2ff14b5cc4384f17f7f45e72eb3 Mon Sep 17 00:00:00 2001
+From 49a24dd349ae99b4009de29935741420fbd523c1 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Mon, 16 May 2022 16:04:27 +0200
 Subject: [PATCH 02/30] krunfw: Ignore run_cmd on orderly reboot
@@ -12,7 +12,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/kernel/reboot.c b/kernel/reboot.c
-index f6947c5bd671..5925d8fcfbfa 100644
+index f6947c5..5925d8f 100644
 --- a/kernel/reboot.c
 +++ b/kernel/reboot.c
 @@ -853,7 +853,11 @@ static int __orderly_reboot(void)

--- a/patches/0003-vsock-dgram-generalize-recvmsg-and-drop-transport-dg.patch
+++ b/patches/0003-vsock-dgram-generalize-recvmsg-and-drop-transport-dg.patch
@@ -1,4 +1,4 @@
-From 72bd47b54d947e297cf4298b8da2cdfc59215135 Mon Sep 17 00:00:00 2001
+From 0c57d06dd234c84b467e07d2ff45bdeeaee28d94 Mon Sep 17 00:00:00 2001
 From: Bobby Eshleman <bobby.eshleman () bytedance ! com>
 Date: Sat, 10 Jun 2023 00:58:28 +0000
 Subject: [PATCH 03/30] vsock/dgram: generalize recvmsg and drop
@@ -23,7 +23,7 @@ Signed-off-by: Bobby Eshleman <bobby.eshleman@bytedance.com>
  9 files changed, 137 insertions(+), 52 deletions(-)
 
 diff --git a/drivers/vhost/vsock.c b/drivers/vhost/vsock.c
-index 78cc66fbb3dd..fee8d1380e95 100644
+index 78cc66f..fee8d13 100644
 --- a/drivers/vhost/vsock.c
 +++ b/drivers/vhost/vsock.c
 @@ -421,9 +421,11 @@ static struct virtio_transport vhost_transport = {
@@ -40,7 +40,7 @@ index 78cc66fbb3dd..fee8d1380e95 100644
  		.stream_enqueue           = virtio_transport_stream_enqueue,
  		.stream_dequeue           = virtio_transport_stream_dequeue,
 diff --git a/include/linux/virtio_vsock.h b/include/linux/virtio_vsock.h
-index 0c67543a45c8..06d5b15642ae 100644
+index 0c67543..06d5b15 100644
 --- a/include/linux/virtio_vsock.h
 +++ b/include/linux/virtio_vsock.h
 @@ -260,6 +260,9 @@ bool virtio_transport_stream_allow(u32 cid, u32 port);
@@ -54,7 +54,7 @@ index 0c67543a45c8..06d5b15642ae 100644
  int virtio_transport_connect(struct vsock_sock *vsk);
  
 diff --git a/include/net/af_vsock.h b/include/net/af_vsock.h
-index 70302c92d329..9ba6e2bcef94 100644
+index 70302c9..9ba6e2b 100644
 --- a/include/net/af_vsock.h
 +++ b/include/net/af_vsock.h
 @@ -120,11 +120,20 @@ struct vsock_transport {
@@ -81,7 +81,7 @@ index 70302c92d329..9ba6e2bcef94 100644
  	/* STREAM. */
  	/* TODO: stream_bind() */
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 1db7a1f8e55f..460c9893e112 100644
+index 1db7a1f..460c989 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -1359,10 +1359,62 @@ static int vsock_dgram_connect(struct socket *sock,
@@ -151,7 +151,7 @@ index 1db7a1f8e55f..460c9893e112 100644
  
  int vsock_dgram_recvmsg(struct socket *sock, struct msghdr *msg,
 diff --git a/net/vmw_vsock/hyperv_transport.c b/net/vmw_vsock/hyperv_transport.c
-index 34871ed1a099..0746f7fb2809 100644
+index 34871ed..0746f7f 100644
 --- a/net/vmw_vsock/hyperv_transport.c
 +++ b/net/vmw_vsock/hyperv_transport.c
 @@ -557,8 +557,17 @@ static int hvs_dgram_bind(struct vsock_sock *vsk, struct sockaddr_vm *addr)
@@ -186,7 +186,7 @@ index 34871ed1a099..0746f7fb2809 100644
  	.dgram_allow              = hvs_dgram_allow,
  
 diff --git a/net/vmw_vsock/virtio_transport.c b/net/vmw_vsock/virtio_transport.c
-index b6569b0ca2bb..d1107b65445e 100644
+index b6569b0..d1107b6 100644
 --- a/net/vmw_vsock/virtio_transport.c
 +++ b/net/vmw_vsock/virtio_transport.c
 @@ -552,9 +552,11 @@ static struct virtio_transport virtio_transport = {
@@ -203,7 +203,7 @@ index b6569b0ca2bb..d1107b65445e 100644
  		.stream_dequeue           = virtio_transport_stream_dequeue,
  		.stream_enqueue           = virtio_transport_stream_enqueue,
 diff --git a/net/vmw_vsock/virtio_transport_common.c b/net/vmw_vsock/virtio_transport_common.c
-index 9550773fe1e1..f5f61f87da83 100644
+index 9550773..f5f61f8 100644
 --- a/net/vmw_vsock/virtio_transport_common.c
 +++ b/net/vmw_vsock/virtio_transport_common.c
 @@ -1053,6 +1053,24 @@ int virtio_transport_dgram_bind(struct vsock_sock *vsk,
@@ -232,7 +232,7 @@ index 9550773fe1e1..f5f61f87da83 100644
  {
  	return false;
 diff --git a/net/vmw_vsock/vmci_transport.c b/net/vmw_vsock/vmci_transport.c
-index aca3132689cf..956109393596 100644
+index aca3132..9561093 100644
 --- a/net/vmw_vsock/vmci_transport.c
 +++ b/net/vmw_vsock/vmci_transport.c
 @@ -1731,57 +1731,40 @@ static int vmci_transport_dgram_enqueue(
@@ -331,7 +331,7 @@ index aca3132689cf..956109393596 100644
  	.stream_enqueue = vmci_transport_stream_enqueue,
  	.stream_has_data = vmci_transport_stream_has_data,
 diff --git a/net/vmw_vsock/vsock_loopback.c b/net/vmw_vsock/vsock_loopback.c
-index 6e78927a598e..3d5e05d8950f 100644
+index 6e78927..3d5e05d 100644
 --- a/net/vmw_vsock/vsock_loopback.c
 +++ b/net/vmw_vsock/vsock_loopback.c
 @@ -66,9 +66,11 @@ static struct virtio_transport loopback_transport = {

--- a/patches/0004-vsock-refactor-transport-lookup-code.patch
+++ b/patches/0004-vsock-refactor-transport-lookup-code.patch
@@ -1,4 +1,4 @@
-From 72e122bd7c78f5ea881fc1be7b81ce6e89bb6a03 Mon Sep 17 00:00:00 2001
+From e64e907039b65c27bd6c5c9c82d375b29ca9e9f6 Mon Sep 17 00:00:00 2001
 From: Bobby Eshleman <bobby.eshleman () bytedance ! com>
 Date: Sat, 10 Jun 2023 00:58:29 +0000
 Subject: [PATCH 04/30] vsock: refactor transport lookup code
@@ -14,7 +14,7 @@ Signed-off-by: Bobby Eshleman <bobby.eshleman@bytedance.com>
  1 file changed, 18 insertions(+), 7 deletions(-)
 
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 460c9893e112..8049e3b4f377 100644
+index 460c989..8049e3b 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -432,6 +432,22 @@ static void vsock_deassign_transport(struct vsock_sock *vsk)

--- a/patches/0005-vsock-support-multi-transport-datagrams.patch
+++ b/patches/0005-vsock-support-multi-transport-datagrams.patch
@@ -1,4 +1,4 @@
-From 6f8f8b27658ac6345af71dea9ef97850faf704cd Mon Sep 17 00:00:00 2001
+From 4b42955a6a2edb88383102a2f58c9decb7a18599 Mon Sep 17 00:00:00 2001
 From: Bobby Eshleman <bobby.eshleman () bytedance ! com>
 Date: Sat, 10 Jun 2023 00:58:30 +0000
 Subject: [PATCH 05/30] vsock: support multi-transport datagrams
@@ -57,7 +57,7 @@ Signed-off-by: Bobby Eshleman <bobby.eshleman@bytedance.com>
  7 files changed, 60 insertions(+), 36 deletions(-)
 
 diff --git a/drivers/vhost/vsock.c b/drivers/vhost/vsock.c
-index fee8d1380e95..03b0e789d161 100644
+index fee8d13..03b0e78 100644
 --- a/drivers/vhost/vsock.c
 +++ b/drivers/vhost/vsock.c
 @@ -421,7 +421,6 @@ static struct virtio_transport vhost_transport = {
@@ -69,7 +69,7 @@ index fee8d1380e95..03b0e789d161 100644
  		.dgram_get_cid		  = virtio_transport_dgram_get_cid,
  		.dgram_get_port		  = virtio_transport_dgram_get_port,
 diff --git a/include/linux/virtio_vsock.h b/include/linux/virtio_vsock.h
-index 06d5b15642ae..6c8791d3bc70 100644
+index 06d5b15..6c8791d 100644
 --- a/include/linux/virtio_vsock.h
 +++ b/include/linux/virtio_vsock.h
 @@ -257,8 +257,6 @@ void virtio_transport_notify_buffer_size(struct vsock_sock *vsk, u64 *val);
@@ -82,7 +82,7 @@ index 06d5b15642ae..6c8791d3bc70 100644
  int virtio_transport_dgram_get_cid(struct sk_buff *skb, unsigned int *cid);
  int virtio_transport_dgram_get_port(struct sk_buff *skb, unsigned int *port);
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 8049e3b4f377..9046ea82a37b 100644
+index 8049e3b..9046ea8 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -448,6 +448,18 @@ vsock_connectible_lookup_transport(unsigned int cid, __u8 flags)
@@ -238,7 +238,7 @@ index 8049e3b4f377..9046ea82a37b 100644
  
  	/* sock map disallows redirection of non-TCP sockets with sk_state !=
 diff --git a/net/vmw_vsock/hyperv_transport.c b/net/vmw_vsock/hyperv_transport.c
-index 0746f7fb2809..b5822a5ed92f 100644
+index 0746f7f..b5822a5 100644
 --- a/net/vmw_vsock/hyperv_transport.c
 +++ b/net/vmw_vsock/hyperv_transport.c
 @@ -552,11 +552,6 @@ static void hvs_destruct(struct vsock_sock *vsk)
@@ -262,7 +262,7 @@ index 0746f7fb2809..b5822a5ed92f 100644
  	.dgram_get_port		  = hvs_dgram_get_port,
  	.dgram_get_length	  = hvs_dgram_get_length,
 diff --git a/net/vmw_vsock/virtio_transport.c b/net/vmw_vsock/virtio_transport.c
-index d1107b65445e..e9828815e741 100644
+index d1107b6..e982881 100644
 --- a/net/vmw_vsock/virtio_transport.c
 +++ b/net/vmw_vsock/virtio_transport.c
 @@ -551,7 +551,6 @@ static struct virtio_transport virtio_transport = {
@@ -274,7 +274,7 @@ index d1107b65445e..e9828815e741 100644
  		.dgram_allow              = virtio_transport_dgram_allow,
  		.dgram_get_cid		  = virtio_transport_dgram_get_cid,
 diff --git a/net/vmw_vsock/virtio_transport_common.c b/net/vmw_vsock/virtio_transport_common.c
-index f5f61f87da83..3a996272764b 100644
+index f5f61f8..3a99627 100644
 --- a/net/vmw_vsock/virtio_transport_common.c
 +++ b/net/vmw_vsock/virtio_transport_common.c
 @@ -1046,13 +1046,6 @@ bool virtio_transport_stream_allow(u32 cid, u32 port)
@@ -292,7 +292,7 @@ index f5f61f87da83..3a996272764b 100644
  {
  	return -EOPNOTSUPP;
 diff --git a/net/vmw_vsock/vsock_loopback.c b/net/vmw_vsock/vsock_loopback.c
-index 3d5e05d8950f..9e9e124f8d2b 100644
+index 3d5e05d..9e9e124 100644
 --- a/net/vmw_vsock/vsock_loopback.c
 +++ b/net/vmw_vsock/vsock_loopback.c
 @@ -65,7 +65,6 @@ static struct virtio_transport loopback_transport = {

--- a/patches/0006-vsock-make-vsock-bind-reusable.patch
+++ b/patches/0006-vsock-make-vsock-bind-reusable.patch
@@ -1,4 +1,4 @@
-From 20265fb6e3a0cb720723450b5fa7e8017616b514 Mon Sep 17 00:00:00 2001
+From 4707d57b715cf4eb08fa9ee9e6b2e0adf634e542 Mon Sep 17 00:00:00 2001
 From: Bobby Eshleman <bobby.eshleman () bytedance ! com>
 Date: Sat, 10 Jun 2023 00:58:31 +0000
 Subject: [PATCH 06/30] vsock: make vsock bind reusable
@@ -12,7 +12,7 @@ Signed-off-by: Bobby Eshleman <bobby.eshleman@bytedance.com>
  1 file changed, 26 insertions(+), 7 deletions(-)
 
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 9046ea82a37b..6d3e95d94f76 100644
+index 9046ea8..6d3e95d 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -235,11 +235,12 @@ static void __vsock_remove_connected(struct vsock_sock *vsk)

--- a/patches/0007-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
+++ b/patches/0007-virtio-vsock-add-VIRTIO_VSOCK_F_DGRAM-feature-bit.patch
@@ -1,4 +1,4 @@
-From afc5971d193d97700ad23b13287fcbcf3c0d2e4a Mon Sep 17 00:00:00 2001
+From c93f6f74d91852481a103d972e554f8db432f7ed Mon Sep 17 00:00:00 2001
 From: Bobby Eshleman <bobby.eshleman () bytedance ! com>
 Date: Sat, 10 Jun 2023 00:58:32 +0000
 Subject: [PATCH 07/30] virtio/vsock: add VIRTIO_VSOCK_F_DGRAM feature bit
@@ -12,7 +12,7 @@ Signed-off-by: Bobby Eshleman <bobby.eshleman@bytedance.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/include/uapi/linux/virtio_vsock.h b/include/uapi/linux/virtio_vsock.h
-index 64738838bee5..9c25f267bbc0 100644
+index 6473883..9c25f26 100644
 --- a/include/uapi/linux/virtio_vsock.h
 +++ b/include/uapi/linux/virtio_vsock.h
 @@ -40,6 +40,7 @@

--- a/patches/0008-virtio-vsock-support-dgrams.patch
+++ b/patches/0008-virtio-vsock-support-dgrams.patch
@@ -1,4 +1,4 @@
-From c9a2af154eb0cc87fd31eea4c536e349dae2f346 Mon Sep 17 00:00:00 2001
+From 0ac72d05f3d52c827d5237ad8bdebb4ace15bfb7 Mon Sep 17 00:00:00 2001
 From: Bobby Eshleman <bobby.eshleman () bytedance ! com>
 Date: Sat, 10 Jun 2023 00:58:33 +0000
 Subject: [PATCH 08/30] virtio/vsock: support dgrams
@@ -36,7 +36,7 @@ Signed-off-by: Bobby Eshleman <bobby.eshleman@bytedance.com>
  8 files changed, 198 insertions(+), 59 deletions(-)
 
 diff --git a/drivers/vhost/vsock.c b/drivers/vhost/vsock.c
-index 03b0e789d161..deaadc2503a2 100644
+index 03b0e78..deaadc2 100644
 --- a/drivers/vhost/vsock.c
 +++ b/drivers/vhost/vsock.c
 @@ -32,7 +32,8 @@
@@ -112,7 +112,7 @@ index 03b0e789d161..deaadc2503a2 100644
  		vq = &vsock->vqs[i];
  		mutex_lock(&vq->mutex);
 diff --git a/include/linux/virtio_vsock.h b/include/linux/virtio_vsock.h
-index 6c8791d3bc70..e3d7afa29894 100644
+index 6c8791d..e3d7afa 100644
 --- a/include/linux/virtio_vsock.h
 +++ b/include/linux/virtio_vsock.h
 @@ -257,7 +257,6 @@ void virtio_transport_notify_buffer_size(struct vsock_sock *vsk, u64 *val);
@@ -133,7 +133,7 @@ index 6c8791d3bc70..e3d7afa29894 100644
 +int virtio_transport_dgram_get_length(struct sk_buff *skb, size_t *len);
  #endif /* _LINUX_VIRTIO_VSOCK_H */
 diff --git a/include/net/af_vsock.h b/include/net/af_vsock.h
-index 9ba6e2bcef94..5f93bb290a83 100644
+index 9ba6e2b..5f93bb2 100644
 --- a/include/net/af_vsock.h
 +++ b/include/net/af_vsock.h
 @@ -230,6 +230,7 @@ void vsock_for_each_connected_socket(struct vsock_transport *transport,
@@ -145,7 +145,7 @@ index 9ba6e2bcef94..5f93bb290a83 100644
  /**** TAP ****/
  
 diff --git a/include/uapi/linux/virtio_vsock.h b/include/uapi/linux/virtio_vsock.h
-index 9c25f267bbc0..27b4b2b8bf13 100644
+index 9c25f26..27b4b2b 100644
 --- a/include/uapi/linux/virtio_vsock.h
 +++ b/include/uapi/linux/virtio_vsock.h
 @@ -70,6 +70,7 @@ struct virtio_vsock_hdr {
@@ -157,7 +157,7 @@ index 9c25f267bbc0..27b4b2b8bf13 100644
  
  enum virtio_vsock_op {
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 6d3e95d94f76..7c9c8696a07a 100644
+index 6d3e95d..7c9c869 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -118,6 +118,7 @@ static int __vsock_bind(struct sock *sk, struct sockaddr_vm *addr);
@@ -267,7 +267,7 @@ index 6d3e95d94f76..7c9c8696a07a 100644
  
  	default:
 diff --git a/net/vmw_vsock/virtio_transport.c b/net/vmw_vsock/virtio_transport.c
-index e9828815e741..58d15edd296e 100644
+index e982881..58d15ed 100644
 --- a/net/vmw_vsock/virtio_transport.c
 +++ b/net/vmw_vsock/virtio_transport.c
 @@ -74,6 +74,7 @@ struct virtio_vsock {
@@ -329,7 +329,7 @@ index e9828815e741..58d15edd296e 100644
  
  static struct virtio_driver virtio_vsock_driver = {
 diff --git a/net/vmw_vsock/virtio_transport_common.c b/net/vmw_vsock/virtio_transport_common.c
-index 3a996272764b..a7e9bcc49a8e 100644
+index 3a99627..a7e9bcc 100644
 --- a/net/vmw_vsock/virtio_transport_common.c
 +++ b/net/vmw_vsock/virtio_transport_common.c
 @@ -227,7 +227,9 @@ EXPORT_SYMBOL_GPL(virtio_transport_deliver_tap_pkt);
@@ -578,7 +578,7 @@ index 3a996272764b..a7e9bcc49a8e 100644
  
  	/* Release refcnt obtained when we fetched this socket out of the
 diff --git a/net/vmw_vsock/vsock_loopback.c b/net/vmw_vsock/vsock_loopback.c
-index 9e9e124f8d2b..b3066c854bb9 100644
+index 9e9e124..b3066c8 100644
 --- a/net/vmw_vsock/vsock_loopback.c
 +++ b/net/vmw_vsock/vsock_loopback.c
 @@ -46,6 +46,7 @@ static int vsock_loopback_cancel_pkt(struct vsock_sock *vsk)

--- a/patches/0009-vsock-Add-support-for-SIOCINQ-ioctl.patch
+++ b/patches/0009-vsock-Add-support-for-SIOCINQ-ioctl.patch
@@ -1,4 +1,4 @@
-From 52e07de426f743550a3954c9d5168ecfe051ef28 Mon Sep 17 00:00:00 2001
+From a2c866397727f8feaced6e55dbf2892cecd7e780 Mon Sep 17 00:00:00 2001
 From: Xuewei Niu <niuxuewei.nxw@antgroup.com>
 Date: Tue, 8 Jul 2025 14:36:12 +0800
 Subject: [PATCH 09/30] vsock: Add support for SIOCINQ ioctl
@@ -18,7 +18,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 22 insertions(+)
 
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 7c9c8696a07a..3b420d8f0c84 100644
+index 7c9c869..3b420d8 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -1545,6 +1545,28 @@ static int vsock_do_ioctl(struct socket *sock, unsigned int cmd,

--- a/patches/0010-virtio-vsock-implement-has_data-for-DGRAM.patch
+++ b/patches/0010-virtio-vsock-implement-has_data-for-DGRAM.patch
@@ -1,4 +1,4 @@
-From adc7bebfd1e4dff1a2160fb587fc534f38463cba Mon Sep 17 00:00:00 2001
+From 98f7ba131c3d858b1e04b71f05ed64d114b928b8 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 28 May 2026 11:43:46 +0200
 Subject: [PATCH 10/30] virtio/vsock: implement has_data for DGRAM
@@ -14,7 +14,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  6 files changed, 34 insertions(+), 1 deletion(-)
 
 diff --git a/include/linux/virtio_vsock.h b/include/linux/virtio_vsock.h
-index e3d7afa29894..34220effc4b0 100644
+index e3d7afa..34220ef 100644
 --- a/include/linux/virtio_vsock.h
 +++ b/include/linux/virtio_vsock.h
 @@ -215,6 +215,7 @@ ssize_t
@@ -26,7 +26,7 @@ index e3d7afa29894..34220effc4b0 100644
  s64 virtio_transport_stream_has_space(struct vsock_sock *vsk);
  u32 virtio_transport_seqpacket_has_data(struct vsock_sock *vsk);
 diff --git a/include/net/af_vsock.h b/include/net/af_vsock.h
-index 5f93bb290a83..45469aa8cf60 100644
+index 5f93bb2..45469aa 100644
 --- a/include/net/af_vsock.h
 +++ b/include/net/af_vsock.h
 @@ -76,6 +76,7 @@ struct vsock_sock {
@@ -46,7 +46,7 @@ index 5f93bb290a83..45469aa8cf60 100644
  	/* STREAM. */
  	/* TODO: stream_bind() */
 diff --git a/net/vmw_vsock/af_vsock.c b/net/vmw_vsock/af_vsock.c
-index 3b420d8f0c84..73e2eac4c3af 100644
+index 3b420d8..73e2eac 100644
 --- a/net/vmw_vsock/af_vsock.c
 +++ b/net/vmw_vsock/af_vsock.c
 @@ -1007,6 +1007,15 @@ s64 vsock_stream_has_data(struct vsock_sock *vsk)
@@ -79,7 +79,7 @@ index 3b420d8f0c84..73e2eac4c3af 100644
  			ret = n_bytes;
  			break;
 diff --git a/net/vmw_vsock/virtio_transport.c b/net/vmw_vsock/virtio_transport.c
-index 58d15edd296e..43eeeb32a318 100644
+index 58d15ed..43eeeb3 100644
 --- a/net/vmw_vsock/virtio_transport.c
 +++ b/net/vmw_vsock/virtio_transport.c
 @@ -558,6 +558,7 @@ static struct virtio_transport virtio_transport = {
@@ -91,7 +91,7 @@ index 58d15edd296e..43eeeb32a318 100644
  		.stream_dequeue           = virtio_transport_stream_dequeue,
  		.stream_enqueue           = virtio_transport_stream_enqueue,
 diff --git a/net/vmw_vsock/virtio_transport_common.c b/net/vmw_vsock/virtio_transport_common.c
-index a7e9bcc49a8e..6498ab12ce31 100644
+index a7e9bcc..6498ab1 100644
 --- a/net/vmw_vsock/virtio_transport_common.c
 +++ b/net/vmw_vsock/virtio_transport_common.c
 @@ -862,6 +862,21 @@ int virtio_transport_dgram_get_length(struct sk_buff *skb, size_t *len)
@@ -117,7 +117,7 @@ index a7e9bcc49a8e..6498ab12ce31 100644
  {
  	struct virtio_vsock_sock *vvs = vsk->trans;
 diff --git a/net/vmw_vsock/vsock_loopback.c b/net/vmw_vsock/vsock_loopback.c
-index b3066c854bb9..09e6162030b0 100644
+index b3066c8..09e6162 100644
 --- a/net/vmw_vsock/vsock_loopback.c
 +++ b/net/vmw_vsock/vsock_loopback.c
 @@ -71,6 +71,7 @@ static struct virtio_transport loopback_transport = {

--- a/patches/0011-Transparent-Socket-Impersonation-implementation.patch
+++ b/patches/0011-Transparent-Socket-Impersonation-implementation.patch
@@ -1,4 +1,4 @@
-From 6ec974c7d185814ca12661e8081dcd4cb4ae179b Mon Sep 17 00:00:00 2001
+From 51b6c98d07bf527bd860a05f7ca593534ce77743 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:38:26 +0200
 Subject: [PATCH 11/30] Transparent Socket Impersonation implementation
@@ -22,6 +22,8 @@ TODO - implement remote [get|set]sockopt
 
 Co-authored-by: Matej Hrica <mhrica@redhat.com>
 
+Assisted-by: OpenCode:claude-opus-4.6
+
 Signed-off-by: Sergio Lopez <slp@redhat.com>
 Signed-off-by: Matej Hrica <mhrica@redhat.com>
 ---
@@ -31,18 +33,18 @@ Signed-off-by: Matej Hrica <mhrica@redhat.com>
  net/socket.c                        |    3 +
  net/tsi/Kconfig                     |    7 +
  net/tsi/Makefile                    |    4 +
- net/tsi/af_tsi.c                    | 1577 +++++++++++++++++++++++++++
- net/tsi/af_tsi.h                    |  107 ++
+ net/tsi/af_tsi.c                    | 1609 +++++++++++++++++++++++++++
+ net/tsi/af_tsi.h                    |  109 ++
  security/selinux/hooks.c            |    8 +-
  security/selinux/include/classmap.h |    3 +-
- 10 files changed, 1716 insertions(+), 3 deletions(-)
+ 10 files changed, 1750 insertions(+), 3 deletions(-)
  create mode 100644 net/tsi/Kconfig
  create mode 100644 net/tsi/Makefile
  create mode 100644 net/tsi/af_tsi.c
  create mode 100644 net/tsi/af_tsi.h
 
 diff --git a/include/linux/socket.h b/include/linux/socket.h
-index c3322eb3d686..5ae7f94b3abc 100644
+index c3322eb..5ae7f94 100644
 --- a/include/linux/socket.h
 +++ b/include/linux/socket.h
 @@ -240,8 +240,11 @@ struct ucred {
@@ -69,7 +71,7 @@ index c3322eb3d686..5ae7f94b3abc 100644
  
  /* Maximum queue length specifiable by listen.  */
 diff --git a/net/Kconfig b/net/Kconfig
-index a629f92dc86b..91dfb9152b5b 100644
+index a629f92..91dfb91 100644
 --- a/net/Kconfig
 +++ b/net/Kconfig
 @@ -274,6 +274,7 @@ source "net/switchdev/Kconfig"
@@ -81,7 +83,7 @@ index a629f92dc86b..91dfb9152b5b 100644
  config PCPU_DEV_REFCNT
  	bool "Use percpu variables to maintain network device refcount"
 diff --git a/net/Makefile b/net/Makefile
-index 65bb8c72a35e..c1db937f3212 100644
+index 65bb8c7..c1db937 100644
 --- a/net/Makefile
 +++ b/net/Makefile
 @@ -79,3 +79,4 @@ obj-$(CONFIG_XDP_SOCKETS)	+= xdp/
@@ -90,7 +92,7 @@ index 65bb8c72a35e..c1db937f3212 100644
  obj-$(CONFIG_NET_HANDSHAKE)	+= handshake/
 +obj-$(CONFIG_TSI)		+= tsi/
 diff --git a/net/socket.c b/net/socket.c
-index 878155076bc0..a55927134851 100644
+index 8781550..a559271 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -217,6 +217,9 @@ static const char * const pf_family_names[] = {
@@ -105,7 +107,7 @@ index 878155076bc0..a55927134851 100644
  /*
 diff --git a/net/tsi/Kconfig b/net/tsi/Kconfig
 new file mode 100644
-index 000000000000..0f52ac6c9fa1
+index 0000000..0f52ac6
 --- /dev/null
 +++ b/net/tsi/Kconfig
 @@ -0,0 +1,7 @@
@@ -118,7 +120,7 @@ index 000000000000..0f52ac6c9fa1
 +	  TSI (Transparent Socket Impersonation).
 diff --git a/net/tsi/Makefile b/net/tsi/Makefile
 new file mode 100644
-index 000000000000..8b3cf74116a5
+index 0000000..8b3cf74
 --- /dev/null
 +++ b/net/tsi/Makefile
 @@ -0,0 +1,4 @@
@@ -128,10 +130,10 @@ index 000000000000..8b3cf74116a5
 +tsi-y := af_tsi.o
 diff --git a/net/tsi/af_tsi.c b/net/tsi/af_tsi.c
 new file mode 100644
-index 000000000000..3d2bcd8d2ba4
+index 0000000..50112f2
 --- /dev/null
 +++ b/net/tsi/af_tsi.c
-@@ -0,0 +1,1577 @@
+@@ -0,0 +1,1609 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +/*
 + * Transparent Socket Impersonation Driver
@@ -177,6 +179,13 @@ index 000000000000..3d2bcd8d2ba4
 +
 +#define tsi_sk(__sk) ((struct tsi_sock *)__sk)
 +#define sk_tsi(__tsk) (&(__tsk)->sk)
++
++static inline bool tsi_is_local_vsock_sockopt(int level, int optname)
++{
++	return level == SOL_SOCKET &&
++	       (optname == SO_RCVTIMEO_OLD || optname == SO_RCVTIMEO_NEW ||
++		optname == SO_SNDTIMEO_OLD || optname == SO_SNDTIMEO_NEW);
++}
 +
 +static int tsi_check_addr_len(struct tsi_sock *tsk, int addr_len)
 +{
@@ -417,6 +426,7 @@ index 000000000000..3d2bcd8d2ba4
 +	tpc.svm_port = tsk->svm_port = vm_addr.svm_port;
 +	tpc.family = tsk->family;
 +	tpc.type = type;
++	tpc.protocol = tsk->protocol;
 +
 +	pr_debug("%s: type=%d\n", __func__, tpc.type);
 +
@@ -1114,6 +1124,24 @@ index 000000000000..3d2bcd8d2ba4
 +
 +	switch (tsk->status) {
 +	case S_HYBRID:
++		if (level == SOL_SOCKET) {
++			err = sock_setsockopt(isocket, level, optname, optval,
++					      optlen);
++
++			if (!err && tsi_is_local_vsock_sockopt(level, optname)) {
++				int err2 = sock_setsockopt(tsk->vsocket, level,
++							   optname, optval, optlen);
++				if (err2)
++					pr_err("%s: vsocket setsockopt(%d) failed: %d\n",
++					       __func__, optname, err2);
++			}
++		} else if (isocket->ops->setsockopt) {
++			err = isocket->ops->setsockopt(isocket, level, optname,
++						       optval, optlen);
++		} else {
++			err = -ENOPROTOOPT;
++		}
++		break;
 +	case S_INET:
 +		if (level == SOL_SOCKET) {
 +			err = sock_setsockopt(isocket, level, optname, optval,
@@ -1126,8 +1154,13 @@ index 000000000000..3d2bcd8d2ba4
 +		}
 +		break;
 +	case S_VSOCK:
-+		// TODO implement remote setsockopt
-+		err = 0;
++		if (tsi_is_local_vsock_sockopt(level, optname)) {
++			err = sock_setsockopt(tsk->vsocket, level, optname,
++					      optval, optlen);
++		} else {
++			/* TODO: forward other options to host */
++			err = 0;
++		}
 +		break;
 +	}
 +
@@ -1589,6 +1622,7 @@ index 000000000000..3d2bcd8d2ba4
 +	tsk->svm_peer_port = TSI_DEFAULT_PORT;
 +	tsk->sendto_addr = NULL;
 +	tsk->bound_addr = NULL;
++	tsk->protocol = protocol;
 +	tsk->family = family;
 +
 +	return 0;
@@ -1711,10 +1745,10 @@ index 000000000000..3d2bcd8d2ba4
 +MODULE_LICENSE("GPL v2");
 diff --git a/net/tsi/af_tsi.h b/net/tsi/af_tsi.h
 new file mode 100644
-index 000000000000..b74966fd7ae3
+index 0000000..05d7a67
 --- /dev/null
 +++ b/net/tsi/af_tsi.h
-@@ -0,0 +1,107 @@
+@@ -0,0 +1,109 @@
 +/* SPDX-License-Identifier: GPL-2.0-only */
 +/*
 + * Transparent Socket Impersonation Driver
@@ -1749,6 +1783,7 @@ index 000000000000..b74966fd7ae3
 +	u32 svm_port;
 +	u16 family;
 +	u16 type;
++	u16 protocol;
 +} __attribute__((packed));
 +
 +struct tsi_connect_req {
@@ -1814,6 +1849,7 @@ index 000000000000..b74966fd7ae3
 +	int bound_addr_len;
 +	int sendto_addr_len;
 +	u16 family;
++	u16 protocol;
 +};
 +
 +struct tsi_proxy_release {
@@ -1823,7 +1859,7 @@ index 000000000000..b74966fd7ae3
 +
 +#endif
 diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
-index 8e31d3b60fc6..aae3267fa9ee 100644
+index 8e31d3b..aae3267 100644
 --- a/security/selinux/hooks.c
 +++ b/security/selinux/hooks.c
 @@ -1302,7 +1302,13 @@ static inline u16 socket_type_to_security_class(int family, int type, int protoc
@@ -1842,7 +1878,7 @@ index 8e31d3b60fc6..aae3267fa9ee 100644
  #endif
  		}
 diff --git a/security/selinux/include/classmap.h b/security/selinux/include/classmap.h
-index 7229c9bf6c27..f08d24321603 100644
+index 7229c9b..f08d243 100644
 --- a/security/selinux/include/classmap.h
 +++ b/security/selinux/include/classmap.h
 @@ -173,6 +173,7 @@ const struct security_class_mapping secclass_map[] = {

--- a/patches/0012-tsi-allow-hijacking-sockets-tsi_hijack.patch
+++ b/patches/0012-tsi-allow-hijacking-sockets-tsi_hijack.patch
@@ -1,4 +1,4 @@
-From 74fbbeb0dcc7e3eb2281b2f10f5ddb3aaa658287 Mon Sep 17 00:00:00 2001
+From 84607b43b06fd51fa6d2f71e502c16c27cc7c33d Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Thu, 19 May 2022 22:42:01 +0200
 Subject: [PATCH 12/30] tsi: allow hijacking sockets (tsi_hijack)
@@ -15,7 +15,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  2 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/net/socket.c b/net/socket.c
-index a55927134851..a355cbd6ba1e 100644
+index a559271..a355cbd 100644
 --- a/net/socket.c
 +++ b/net/socket.c
 @@ -115,6 +115,11 @@ unsigned int sysctl_net_busy_read __read_mostly;
@@ -68,10 +68,10 @@ index a55927134851..a355cbd6ba1e 100644
  	pf = rcu_dereference(net_families[family]);
  	err = -EAFNOSUPPORT;
 diff --git a/net/tsi/af_tsi.c b/net/tsi/af_tsi.c
-index 3d2bcd8d2ba4..bd3dc75b3129 100644
+index 50112f2..7f5537e 100644
 --- a/net/tsi/af_tsi.c
 +++ b/net/tsi/af_tsi.c
-@@ -547,7 +547,7 @@ static int tsi_accept(struct socket *sock, struct socket *newsock,
+@@ -555,7 +555,7 @@ static int tsi_accept(struct socket *sock, struct socket *newsock,
  	struct socket *csocket;
  	struct tsi_sock *tsk;
  	struct tsi_sock *newtsk;

--- a/patches/0013-arm64-cpufeature-Unify-SCOPE_LOCAL_CPU-early-late-be.patch
+++ b/patches/0013-arm64-cpufeature-Unify-SCOPE_LOCAL_CPU-early-late-be.patch
@@ -1,4 +1,4 @@
-From f01cba8b91ebd60437f1e4a15e03737fc4fa12f0 Mon Sep 17 00:00:00 2001
+From 97e2f9b452b63ead4ab5d1ca5f6ff3e31ac94d6a Mon Sep 17 00:00:00 2001
 From: Asahi Lina <lina@asahilina.net>
 Date: Wed, 25 Sep 2024 16:35:34 +0200
 Subject: [PATCH 13/30] arm64: cpufeature: Unify SCOPE_LOCAL_CPU early & late
@@ -35,7 +35,7 @@ Signed-off-by: Asahi Lina <lina@asahilina.net>
  1 file changed, 31 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/kernel/cpufeature.c b/arch/arm64/kernel/cpufeature.c
-index 8246015fd2d7..b5bdb19c131f 100644
+index 8246015..b5bdb19 100644
 --- a/arch/arm64/kernel/cpufeature.c
 +++ b/arch/arm64/kernel/cpufeature.c
 @@ -3187,10 +3187,38 @@ static void update_cpu_capabilities(u16 scope_mask)

--- a/patches/0014-prctl-Introduce-PR_-SET-GET-_MEM_MODEL.patch
+++ b/patches/0014-prctl-Introduce-PR_-SET-GET-_MEM_MODEL.patch
@@ -1,4 +1,4 @@
-From 459cc55cfcca8d65239aa8d2f51d210b1b7d9016 Mon Sep 17 00:00:00 2001
+From f50ae28a104babafea6d446a139fcf59d42f7fe3 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:20 +0900
 Subject: [PATCH 14/30] prctl: Introduce PR_{SET,GET}_MEM_MODEL
@@ -43,7 +43,7 @@ Reviewed-by: Neal Gompa <neal@gompa.dev>
 
 diff --git a/include/linux/memory_ordering_model.h b/include/linux/memory_ordering_model.h
 new file mode 100644
-index 000000000000..267a12ca6630
+index 0000000..267a12c
 --- /dev/null
 +++ b/include/linux/memory_ordering_model.h
 @@ -0,0 +1,11 @@
@@ -59,7 +59,7 @@ index 000000000000..267a12ca6630
 +
 +#endif
 diff --git a/include/uapi/linux/prctl.h b/include/uapi/linux/prctl.h
-index 35791791a879..36c278683cd6 100644
+index 3579179..36c2786 100644
 --- a/include/uapi/linux/prctl.h
 +++ b/include/uapi/linux/prctl.h
 @@ -328,4 +328,9 @@ struct prctl_mm_map {
@@ -73,7 +73,7 @@ index 35791791a879..36c278683cd6 100644
 +
  #endif /* _LINUX_PRCTL_H */
 diff --git a/kernel/sys.c b/kernel/sys.c
-index 8283e35c9eeb..b14846a80169 100644
+index 8283e35..b14846a 100644
 --- a/kernel/sys.c
 +++ b/kernel/sys.c
 @@ -45,6 +45,7 @@

--- a/patches/0015-arm64-Implement-PR_-GET-SET-_MEM_MODEL-for-always-TS.patch
+++ b/patches/0015-arm64-Implement-PR_-GET-SET-_MEM_MODEL-for-always-TS.patch
@@ -1,4 +1,4 @@
-From 3e558b0b5aff5580bb9ed17828728c590d4d286f Mon Sep 17 00:00:00 2001
+From dd09b10b00f100719bfd2c6be4abc91d128cd5f5 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:21 +0900
 Subject: [PATCH 15/30] arm64: Implement PR_{GET,SET}_MEM_MODEL for always-TSO
@@ -27,7 +27,7 @@ Reviewed-by: Neal Gompa <neal@gompa.dev>
  create mode 100644 arch/arm64/kernel/cpufeature_impdef.c
 
 diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
-index f487c5e21e2f..8f97145095e0 100644
+index f487c5e..8f97145 100644
 --- a/arch/arm64/Kconfig
 +++ b/arch/arm64/Kconfig
 @@ -2264,6 +2264,15 @@ config ARM64_DEBUG_PRIORITY_MASKING
@@ -47,7 +47,7 @@ index f487c5e21e2f..8f97145095e0 100644
  	bool "Build a relocatable kernel image" if EXPERT
  	select ARCH_HAS_RELR
 diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
-index 3d261cc123c1..c4379bde9a26 100644
+index 3d261cc..c4379bd 100644
 --- a/arch/arm64/include/asm/cpufeature.h
 +++ b/arch/arm64/include/asm/cpufeature.h
 @@ -1038,6 +1038,10 @@ static inline bool cpu_has_lpa2(void)
@@ -62,7 +62,7 @@ index 3d261cc123c1..c4379bde9a26 100644
  
  #endif
 diff --git a/arch/arm64/kernel/Makefile b/arch/arm64/kernel/Makefile
-index 2b112f3b7510..2a11cdefbe04 100644
+index 2b112f3..2a11cde 100644
 --- a/arch/arm64/kernel/Makefile
 +++ b/arch/arm64/kernel/Makefile
 @@ -33,7 +33,8 @@ obj-y			:= debug-monitors.o entry.o irq.o fpsimd.o		\
@@ -76,7 +76,7 @@ index 2b112f3b7510..2a11cdefbe04 100644
  obj-$(CONFIG_COMPAT)			+= sys32.o signal32.o			\
  					   sys_compat.o
 diff --git a/arch/arm64/kernel/cpufeature.c b/arch/arm64/kernel/cpufeature.c
-index b5bdb19c131f..4782d643ebed 100644
+index b5bdb19..4782d64 100644
 --- a/arch/arm64/kernel/cpufeature.c
 +++ b/arch/arm64/kernel/cpufeature.c
 @@ -1039,7 +1039,7 @@ static void init_cpu_ftr_reg(u32 sys_reg, u64 new)
@@ -126,7 +126,7 @@ index b5bdb19c131f..4782d643ebed 100644
  	 * Detect broken pseudo-NMI. Must be called _before_ the call to
 diff --git a/arch/arm64/kernel/cpufeature_impdef.c b/arch/arm64/kernel/cpufeature_impdef.c
 new file mode 100644
-index 000000000000..de784a1fb49b
+index 0000000..de784a1
 --- /dev/null
 +++ b/arch/arm64/kernel/cpufeature_impdef.c
 @@ -0,0 +1,38 @@
@@ -169,7 +169,7 @@ index 000000000000..de784a1fb49b
 +	init_cpucap_indirect_list_from_array(arm64_impdef_features);
 +}
 diff --git a/arch/arm64/kernel/process.c b/arch/arm64/kernel/process.c
-index 2edf88c1c695..c753a0f6183b 100644
+index 2edf88c..c753a0f 100644
 --- a/arch/arm64/kernel/process.c
 +++ b/arch/arm64/kernel/process.c
 @@ -41,6 +41,7 @@
@@ -218,7 +218,7 @@ index 2edf88c1c695..c753a0f6183b 100644
  
  #ifdef CONFIG_ARM64_TAGGED_ADDR_ABI
 diff --git a/arch/arm64/tools/cpucaps b/arch/arm64/tools/cpucaps
-index eedb5acc21ed..bca63481e0cf 100644
+index eedb5ac..bca6348 100644
 --- a/arch/arm64/tools/cpucaps
 +++ b/arch/arm64/tools/cpucaps
 @@ -53,6 +53,7 @@ HAS_STAGE2_FWB

--- a/patches/0016-arm64-Introduce-scaffolding-to-add-ACTLR_EL1-to-thre.patch
+++ b/patches/0016-arm64-Introduce-scaffolding-to-add-ACTLR_EL1-to-thre.patch
@@ -1,4 +1,4 @@
-From 47d48798b891f67b109323a65894a00b4bf90f84 Mon Sep 17 00:00:00 2001
+From 2b1981d090563def29a59ee8e679f1576bcc7b68 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:22 +0900
 Subject: [PATCH 16/30] arm64: Introduce scaffolding to add ACTLR_EL1 to thread
@@ -24,7 +24,7 @@ Reviewed-by: Neal Gompa <neal@gompa.dev>
  5 files changed, 44 insertions(+)
 
 diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
-index 8f97145095e0..8d587e0b21ef 100644
+index 8f97145..8d587e0 100644
 --- a/arch/arm64/Kconfig
 +++ b/arch/arm64/Kconfig
 @@ -430,6 +430,9 @@ config KASAN_SHADOW_OFFSET
@@ -38,7 +38,7 @@ index 8f97145095e0..8d587e0b21ef 100644
  
  menu "Kernel Features"
 diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
-index c4379bde9a26..1775e210f04f 100644
+index c4379bd..1775e21 100644
 --- a/arch/arm64/include/asm/cpufeature.h
 +++ b/arch/arm64/include/asm/cpufeature.h
 @@ -915,6 +915,11 @@ static inline unsigned int get_vmid_bits(u64 mmfr1)
@@ -54,7 +54,7 @@ index c4379bde9a26..1775e210f04f 100644
  struct arm64_ftr_reg *get_arm64_ftr_reg(u32 sys_id);
  
 diff --git a/arch/arm64/include/asm/processor.h b/arch/arm64/include/asm/processor.h
-index 1438424f0064..ea4e32467068 100644
+index 1438424..ea4e324 100644
 --- a/arch/arm64/include/asm/processor.h
 +++ b/arch/arm64/include/asm/processor.h
 @@ -185,6 +185,9 @@ struct thread_struct {
@@ -68,7 +68,7 @@ index 1438424f0064..ea4e32467068 100644
  
  static inline unsigned int thread_get_vl(struct thread_struct *thread,
 diff --git a/arch/arm64/kernel/process.c b/arch/arm64/kernel/process.c
-index c753a0f6183b..f2bf5f7d6dbb 100644
+index c753a0f..f2bf5f7 100644
 --- a/arch/arm64/kernel/process.c
 +++ b/arch/arm64/kernel/process.c
 @@ -385,6 +385,11 @@ int copy_thread(struct task_struct *p, const struct kernel_clone_args *args)
@@ -118,7 +118,7 @@ index c753a0f6183b..f2bf5f7d6dbb 100644
  	/*
  	 * Complete any pending TLB or cache maintenance on this CPU in case
 diff --git a/arch/arm64/kernel/setup.c b/arch/arm64/kernel/setup.c
-index 8185979f0f11..4fcaaf9c7d2b 100644
+index 8185979..4fcaaf9 100644
 --- a/arch/arm64/kernel/setup.c
 +++ b/arch/arm64/kernel/setup.c
 @@ -367,6 +367,14 @@ void __init __no_sanitize_address setup_arch(char **cmdline_p)

--- a/patches/0017-arm64-Implement-Apple-IMPDEF-TSO-memory-model-contro.patch
+++ b/patches/0017-arm64-Implement-Apple-IMPDEF-TSO-memory-model-contro.patch
@@ -1,4 +1,4 @@
-From 216f355fcd34b92266691cff5ce806d8f6b42fd3 Mon Sep 17 00:00:00 2001
+From 27b438f035bae8500fec2e80d4f9c9f6640cb5b7 Mon Sep 17 00:00:00 2001
 From: Hector Martin <marcan@marcan.st>
 Date: Thu, 11 Apr 2024 09:51:23 +0900
 Subject: [PATCH 17/30] arm64: Implement Apple IMPDEF TSO memory model control
@@ -27,7 +27,7 @@ Reviewed-by: Neal Gompa <neal@gompa.dev>
  create mode 100644 arch/arm64/include/asm/apple_cpufeature.h
 
 diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
-index 8d587e0b21ef..befa467fd555 100644
+index 8d587e0..befa467 100644
 --- a/arch/arm64/Kconfig
 +++ b/arch/arm64/Kconfig
 @@ -2269,6 +2269,8 @@ endif # ARM64_PSEUDO_NMI
@@ -41,7 +41,7 @@ index 8d587e0b21ef..befa467fd555 100644
  	  model, which can be useful to emulate other CPU architectures
 diff --git a/arch/arm64/include/asm/apple_cpufeature.h b/arch/arm64/include/asm/apple_cpufeature.h
 new file mode 100644
-index 000000000000..4370d91ffa3e
+index 0000000..4370d91
 --- /dev/null
 +++ b/arch/arm64/include/asm/apple_cpufeature.h
 @@ -0,0 +1,15 @@
@@ -61,7 +61,7 @@ index 000000000000..4370d91ffa3e
 +
 +#endif
 diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
-index 1775e210f04f..6343a192aba1 100644
+index 1775e21..6343a19 100644
 --- a/arch/arm64/include/asm/cpufeature.h
 +++ b/arch/arm64/include/asm/cpufeature.h
 @@ -917,7 +917,8 @@ static inline unsigned int get_vmid_bits(u64 mmfr1)
@@ -75,7 +75,7 @@ index 1775e210f04f..6343a192aba1 100644
  
  s64 arm64_ftr_safe_value(const struct arm64_ftr_bits *ftrp, s64 new, s64 cur);
 diff --git a/arch/arm64/kernel/cpufeature_impdef.c b/arch/arm64/kernel/cpufeature_impdef.c
-index de784a1fb49b..3b0807bf90cd 100644
+index de784a1..3b0807b 100644
 --- a/arch/arm64/kernel/cpufeature_impdef.c
 +++ b/arch/arm64/kernel/cpufeature_impdef.c
 @@ -3,9 +3,51 @@
@@ -149,7 +149,7 @@ index de784a1fb49b..3b0807bf90cd 100644
  		.desc = "TSO memory model (Fixed)",
  		.capability = ARM64_HAS_TSO_FIXED,
 diff --git a/arch/arm64/kernel/process.c b/arch/arm64/kernel/process.c
-index f2bf5f7d6dbb..46f01d4e9fb7 100644
+index f2bf5f7..46f01d4 100644
 --- a/arch/arm64/kernel/process.c
 +++ b/arch/arm64/kernel/process.c
 @@ -44,6 +44,7 @@
@@ -196,7 +196,7 @@ index f2bf5f7d6dbb..46f01d4e9fb7 100644
  		return 0;
  
 diff --git a/arch/arm64/tools/cpucaps b/arch/arm64/tools/cpucaps
-index bca63481e0cf..8b809992a9ee 100644
+index bca6348..8b80999 100644
 --- a/arch/arm64/tools/cpucaps
 +++ b/arch/arm64/tools/cpucaps
 @@ -53,6 +53,7 @@ HAS_STAGE2_FWB

--- a/patches/0018-drm-virtio-Support-fence-passing-feature.patch
+++ b/patches/0018-drm-virtio-Support-fence-passing-feature.patch
@@ -1,4 +1,4 @@
-From c3b36d4d123ef1e99b504ebb4eac2f46bf3e9da3 Mon Sep 17 00:00:00 2001
+From 7df08fcba2eead52f273e3583ff86ce9623f6c6b Mon Sep 17 00:00:00 2001
 From: Dmitry Osipenko <dmitry.osipenko@collabora.com>
 Date: Sat, 7 Oct 2023 22:47:47 +0300
 Subject: [PATCH 18/30] drm/virtio: Support fence-passing feature
@@ -36,7 +36,7 @@ Signed-off-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
  9 files changed, 152 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.c b/drivers/gpu/drm/virtio/virtgpu_drv.c
-index e5a2665e50ea..33b471dfe098 100644
+index e5a2665..33b471d 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_drv.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_drv.c
 @@ -149,6 +149,7 @@ static unsigned int features[] = {
@@ -48,7 +48,7 @@ index e5a2665e50ea..33b471dfe098 100644
  static struct virtio_driver virtio_gpu_driver = {
  	.feature_table = features,
 diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.h b/drivers/gpu/drm/virtio/virtgpu_drv.h
-index 5dc8eeaf7123..50d8bbd01bc4 100644
+index 5dc8eea..50d8bbd 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_drv.h
 +++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
 @@ -152,6 +152,7 @@ struct virtio_gpu_fence {
@@ -105,7 +105,7 @@ index 5dc8eeaf7123..50d8bbd01bc4 100644
  /* virtgpu_object.c */
  void virtio_gpu_cleanup_object(struct virtio_gpu_object *bo);
 diff --git a/drivers/gpu/drm/virtio/virtgpu_fence.c b/drivers/gpu/drm/virtio/virtgpu_fence.c
-index f28357dbde35..1fd3cfeca2f5 100644
+index f28357d..1fd3cfe 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_fence.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_fence.c
 @@ -27,9 +27,6 @@
@@ -145,7 +145,7 @@ index f28357dbde35..1fd3cfeca2f5 100644
  
  void virtio_gpu_fence_event_process(struct virtio_gpu_device *vgdev,
 diff --git a/drivers/gpu/drm/virtio/virtgpu_ioctl.c b/drivers/gpu/drm/virtio/virtgpu_ioctl.c
-index e4f76f315550..894f3fd14c51 100644
+index e4f76f3..894f3fd 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_ioctl.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_ioctl.c
 @@ -524,7 +524,8 @@ static int virtio_gpu_resource_create_blob_ioctl(struct drm_device *dev,
@@ -174,7 +174,7 @@ index e4f76f315550..894f3fd14c51 100644
  			ret = -EINVAL;
  			goto out_unlock;
 diff --git a/drivers/gpu/drm/virtio/virtgpu_kms.c b/drivers/gpu/drm/virtio/virtgpu_kms.c
-index 7dfb2006c561..fa4e5542fe5b 100644
+index 7dfb200..fa4e554 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_kms.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_kms.c
 @@ -196,12 +196,16 @@ int virtio_gpu_init(struct virtio_device *vdev, struct drm_device *dev)
@@ -197,7 +197,7 @@ index 7dfb2006c561..fa4e5542fe5b 100644
  	DRM_INFO("features: %ccontext_init\n",
  		 vgdev->has_context_init ? '+' : '-');
 diff --git a/drivers/gpu/drm/virtio/virtgpu_submit.c b/drivers/gpu/drm/virtio/virtgpu_submit.c
-index 7d34cf83f5f2..136ca6238ab0 100644
+index 7d34cf8..136ca62 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_submit.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_submit.c
 @@ -25,6 +25,11 @@ struct virtio_gpu_submit_post_dep {
@@ -364,7 +364,7 @@ index 7d34cf83f5f2..136ca6238ab0 100644
  	/*
  	 * Set up user-out data after submitting the job to optimize
 diff --git a/drivers/gpu/drm/virtio/virtgpu_vq.c b/drivers/gpu/drm/virtio/virtgpu_vq.c
-index 0d3d0d09f39b..96f0a42d313c 100644
+index 0d3d0d0..96f0a42 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_vq.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
 @@ -1079,7 +1079,9 @@ void virtio_gpu_cmd_submit(struct virtio_gpu_device *vgdev,
@@ -389,7 +389,7 @@ index 0d3d0d09f39b..96f0a42d313c 100644
  	virtio_gpu_queue_fenced_ctrl_buffer(vgdev, vbuf, fence);
  }
 diff --git a/include/uapi/drm/virtgpu_drm.h b/include/uapi/drm/virtgpu_drm.h
-index c2ce71987e9b..2bb2d3a0c7bd 100644
+index c2ce719..2bb2d3a 100644
 --- a/include/uapi/drm/virtgpu_drm.h
 +++ b/include/uapi/drm/virtgpu_drm.h
 @@ -52,10 +52,12 @@ extern "C" {
@@ -414,7 +414,7 @@ index c2ce71987e9b..2bb2d3a0c7bd 100644
  	__u64 param;
  	__u64 value;
 diff --git a/include/uapi/linux/virtio_gpu.h b/include/uapi/linux/virtio_gpu.h
-index bf2c9cabd207..ceb656264aa0 100644
+index bf2c9ca..ceb6562 100644
 --- a/include/uapi/linux/virtio_gpu.h
 +++ b/include/uapi/linux/virtio_gpu.h
 @@ -65,6 +65,11 @@

--- a/patches/0019-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
+++ b/patches/0019-Enable-64-bit-processes-to-use-compat-input-syscalls.patch
@@ -1,4 +1,4 @@
-From d3920429863c6170d65b717cab9365af3decedb1 Mon Sep 17 00:00:00 2001
+From c4c6da7d0b51fa9edc9343812bc5befe98e6df0c Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Tue, 8 Oct 2024 11:24:25 +0200
 Subject: [PATCH 19/30] Enable 64 bit processes to use compat input syscalls
@@ -20,7 +20,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  5 files changed, 29 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/input/input-compat.c b/drivers/input/input-compat.c
-index 2ccd3eedbd67..abb8cfb99d6c 100644
+index 2ccd3ee..abb8cfb 100644
 --- a/drivers/input/input-compat.c
 +++ b/drivers/input/input-compat.c
 @@ -14,7 +14,7 @@
@@ -51,7 +51,7 @@ index 2ccd3eedbd67..abb8cfb99d6c 100644
  
  		if (size != sizeof(struct ff_effect_compat))
 diff --git a/drivers/input/input-compat.h b/drivers/input/input-compat.h
-index 3b7bb12b023b..e78c0492ce0d 100644
+index 3b7bb12..e78c049 100644
 --- a/drivers/input/input-compat.h
 +++ b/drivers/input/input-compat.h
 @@ -53,7 +53,7 @@ struct ff_effect_compat {
@@ -64,7 +64,7 @@ index 3b7bb12b023b..e78c0492ce0d 100644
  }
  
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 2e4c437c7c90..f5237065e9fa 100644
+index 2e4c437..f523706 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -1606,6 +1606,11 @@ struct task_struct {
@@ -80,7 +80,7 @@ index 2e4c437c7c90..f5237065e9fa 100644
  	/*
  	 * New fields for task_struct should be added above here, so that
 diff --git a/include/uapi/linux/prctl.h b/include/uapi/linux/prctl.h
-index 36c278683cd6..c2027aa99409 100644
+index 36c2786..c2027aa 100644
 --- a/include/uapi/linux/prctl.h
 +++ b/include/uapi/linux/prctl.h
 @@ -333,4 +333,9 @@ struct prctl_mm_map {
@@ -94,7 +94,7 @@ index 36c278683cd6..c2027aa99409 100644
 +
  #endif /* _LINUX_PRCTL_H */
 diff --git a/kernel/sys.c b/kernel/sys.c
-index b14846a80169..f98671f25026 100644
+index b14846a..f98671f 100644
 --- a/kernel/sys.c
 +++ b/kernel/sys.c
 @@ -2818,6 +2818,21 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,

--- a/patches/0020-dax-Allow-block-size-PAGE_SIZE.patch
+++ b/patches/0020-dax-Allow-block-size-PAGE_SIZE.patch
@@ -1,4 +1,4 @@
-From d72b2bc30adfd622d8e742088d5012fcb3dd2204 Mon Sep 17 00:00:00 2001
+From 628ca54372c2ba313114f82c7c9131659a165705 Mon Sep 17 00:00:00 2001
 From: Asahi Lina <lina@asahilina.net>
 Date: Sun, 20 Oct 2024 01:23:41 +0900
 Subject: [PATCH 20/30] dax: Allow block size > PAGE_SIZE
@@ -22,7 +22,7 @@ Signed-off-by: Asahi Lina <lina@asahilina.net>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/fs/dax.c b/fs/dax.c
-index 756400f2a625..cb155ec940d5 100644
+index 756400f..cb155ec 100644
 --- a/fs/dax.c
 +++ b/fs/dax.c
 @@ -1032,7 +1032,7 @@ int dax_writeback_mapping_range(struct address_space *mapping,

--- a/patches/0021-mm-Fix-__wp_page_copy_user-fallback-path-for-remote-.patch
+++ b/patches/0021-mm-Fix-__wp_page_copy_user-fallback-path-for-remote-.patch
@@ -1,4 +1,4 @@
-From 20ee624fc9fc4d7aca5e78cb412d1525d02d65c8 Mon Sep 17 00:00:00 2001
+From 19a4389f05ae6b56beac494de436a557db98d8f2 Mon Sep 17 00:00:00 2001
 From: Asahi Lina <lina@asahilina.net>
 Date: Mon, 21 Oct 2024 23:21:16 +0900
 Subject: [PATCH 21/30] mm: Fix __wp_page_copy_user fallback path for remote mm
@@ -58,7 +58,7 @@ Signed-off-by: Asahi Lina <lina@asahilina.net>
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/mm/memory.c b/mm/memory.c
-index 49ee03c4392e..45170cc2cd56 100644
+index 49ee03c..45170cc 100644
 --- a/mm/memory.c
 +++ b/mm/memory.c
 @@ -3081,13 +3081,18 @@ static inline int __wp_page_copy_user(struct page *dst, struct page *src,

--- a/patches/0022-virtgpu-gem-partial-map.patch
+++ b/patches/0022-virtgpu-gem-partial-map.patch
@@ -1,4 +1,4 @@
-From 9bf460694c54290ee95eb4282ad4d2a5e44b2fe6 Mon Sep 17 00:00:00 2001
+From 130e67e5ed7f23fd8ffcbf825af32b45580cf330 Mon Sep 17 00:00:00 2001
 From: Sasha Finkelstein <fnkl.kernel@gmail.com>
 Date: Fri, 17 Jan 2025 12:34:23 +0100
 Subject: [PATCH 22/30] virtgpu: gem partial map
@@ -11,7 +11,7 @@ Signed-off-by: Sasha Finkelstein <fnkl.kernel@gmail.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/gpu/drm/virtio/virtgpu_vram.c b/drivers/gpu/drm/virtio/virtgpu_vram.c
-index 25df81c02783..64e2c6dbdd67 100644
+index 25df81c..64e2c6d 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_vram.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_vram.c
 @@ -56,12 +56,11 @@ static int virtio_gpu_vram_mmap(struct drm_gem_object *obj,

--- a/patches/0023-virtgpu-mixed-page-size.patch
+++ b/patches/0023-virtgpu-mixed-page-size.patch
@@ -1,4 +1,4 @@
-From a0b79cf260e7bceddbb93d4dc91157d2ceb67605 Mon Sep 17 00:00:00 2001
+From 4403075e583835a44bf48f1d2dc5eedf8a3832a7 Mon Sep 17 00:00:00 2001
 From: Sasha Finkelstein <fnkl.kernel@gmail.com>
 Date: Fri, 17 Jan 2025 12:34:28 +0100
 Subject: [PATCH 23/30] virtgpu: mixed page size
@@ -12,7 +12,7 @@ Signed-off-by: Sasha Finkelstein <fnkl.kernel@gmail.com>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/virtio/virtgpu_vram.c b/drivers/gpu/drm/virtio/virtgpu_vram.c
-index 64e2c6dbdd67..cbadcba2c773 100644
+index 64e2c6d..cbadcba 100644
 --- a/drivers/gpu/drm/virtio/virtgpu_vram.c
 +++ b/drivers/gpu/drm/virtio/virtgpu_vram.c
 @@ -137,6 +137,12 @@ bool virtio_gpu_is_vram(struct virtio_gpu_object *bo)

--- a/patches/0024-fuse-mark-DAX-inode-releases-as-blocking.patch
+++ b/patches/0024-fuse-mark-DAX-inode-releases-as-blocking.patch
@@ -1,4 +1,4 @@
-From 5d876db7ea5379b0cc6673a02ce8095b804a0e66 Mon Sep 17 00:00:00 2001
+From 42ca1907bd56ca51162b24350f9cc2242f26b6e5 Mon Sep 17 00:00:00 2001
 From: Sergio Lopez <slp@redhat.com>
 Date: Sun, 18 Jan 2026 23:37:30 +0100
 Subject: [PATCH 24/30] fuse: mark DAX inode releases as blocking
@@ -51,7 +51,7 @@ Signed-off-by: Sergio Lopez <slp@redhat.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/fs/fuse/file.c b/fs/fuse/file.c
-index 23afaadd5f3e..e59a08c71f12 100644
+index 23afaad..e59a08c 100644
 --- a/fs/fuse/file.c
 +++ b/fs/fuse/file.c
 @@ -116,6 +116,12 @@ static void fuse_file_put(struct fuse_file *ff, bool sync)

--- a/patches/0025-can-virtio-Add-virtio-CAN-driver.patch
+++ b/patches/0025-can-virtio-Add-virtio-CAN-driver.patch
@@ -1,4 +1,4 @@
-From 7931cf4e2ebc6bd096ae5d3a891e1afa47ec3e35 Mon Sep 17 00:00:00 2001
+From e8f75697691c95421d34b14d1e7016d02ae4c85f Mon Sep 17 00:00:00 2001
 From: Matias Ezequiel Vara Larsen <mvaralar@redhat.com>
 Date: Fri, 8 May 2026 14:23:37 +0200
 Subject: [PATCH 25/30] can: virtio: Add virtio CAN driver
@@ -36,7 +36,7 @@ Signed-off-by: Matias Ezequiel Vara Larsen <mvaralar@redhat.com>
  create mode 100644 include/uapi/linux/virtio_can.h
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index d765c62c80ea..9ecb818f7ddb 100644
+index d765c62..9ecb818 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -24464,6 +24464,15 @@ F:	drivers/scsi/virtio_scsi.c
@@ -56,7 +56,7 @@ index d765c62c80ea..9ecb818f7ddb 100644
  M:	Amit Shah <amit@kernel.org>
  L:	virtualization@lists.linux.dev
 diff --git a/drivers/net/can/Kconfig b/drivers/net/can/Kconfig
-index cf989bea9aa3..851749f76d7c 100644
+index cf989be..851749f 100644
 --- a/drivers/net/can/Kconfig
 +++ b/drivers/net/can/Kconfig
 @@ -208,6 +208,18 @@ config CAN_TI_HECC
@@ -79,7 +79,7 @@ index cf989bea9aa3..851749f76d7c 100644
  	tristate "Xilinx CAN"
  	depends on ARCH_ZYNQ || ARM64 || MICROBLAZE || COMPILE_TEST
 diff --git a/drivers/net/can/Makefile b/drivers/net/can/Makefile
-index a71db2cfe990..ddfe0df9b10b 100644
+index a71db2c..ddfe0df 100644
 --- a/drivers/net/can/Makefile
 +++ b/drivers/net/can/Makefile
 @@ -32,6 +32,7 @@ obj-$(CONFIG_CAN_PEAK_PCIEFD)	+= peak_canfd/
@@ -92,7 +92,7 @@ index a71db2cfe990..ddfe0df9b10b 100644
  subdir-ccflags-$(CONFIG_CAN_DEBUG_DEVICES) += -DDEBUG
 diff --git a/drivers/net/can/virtio_can.c b/drivers/net/can/virtio_can.c
 new file mode 100644
-index 000000000000..0344dd03bd82
+index 0000000..0344dd0
 --- /dev/null
 +++ b/drivers/net/can/virtio_can.c
 @@ -0,0 +1,991 @@
@@ -1089,7 +1089,7 @@ index 000000000000..0344dd03bd82
 +MODULE_DESCRIPTION("CAN bus driver for Virtio CAN controller");
 diff --git a/include/uapi/linux/virtio_can.h b/include/uapi/linux/virtio_can.h
 new file mode 100644
-index 000000000000..08d7e3e78776
+index 0000000..08d7e3e
 --- /dev/null
 +++ b/include/uapi/linux/virtio_can.h
 @@ -0,0 +1,78 @@

--- a/patches/0026-virtio_rtc-Add-module-and-driver-core.patch
+++ b/patches/0026-virtio_rtc-Add-module-and-driver-core.patch
@@ -1,4 +1,4 @@
-From ecb8b27ab26a3b2c186fe1b0f0b6297ad57421cd Mon Sep 17 00:00:00 2001
+From ddf2b12fe7d90058e929999e49b12a8ae24672cb Mon Sep 17 00:00:00 2001
 From: Peter Hilber <quic_philber@quicinc.com>
 Date: Fri, 9 May 2025 18:07:22 +0200
 Subject: [PATCH 26/30] virtio_rtc: Add module and driver core
@@ -34,7 +34,7 @@ Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
  create mode 100644 include/uapi/linux/virtio_rtc.h
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 9ecb818f7ddb..ebf1a598394c 100644
+index 9ecb818..ebf1a59 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -24620,6 +24620,13 @@ S:	Maintained
@@ -52,7 +52,7 @@ index 9ecb818f7ddb..ebf1a598394c 100644
  M:	Anton Yakovlev <anton.yakovlev@opensynergy.com>
  M:	"Michael S. Tsirkin" <mst@redhat.com>
 diff --git a/drivers/virtio/Kconfig b/drivers/virtio/Kconfig
-index 42a48ac763ee..fd6b826af19a 100644
+index 42a48ac..fd6b826 100644
 --- a/drivers/virtio/Kconfig
 +++ b/drivers/virtio/Kconfig
 @@ -188,4 +188,17 @@ config VIRTIO_DEBUG
@@ -74,7 +74,7 @@ index 42a48ac763ee..fd6b826af19a 100644
 +
  endif # VIRTIO_MENU
 diff --git a/drivers/virtio/Makefile b/drivers/virtio/Makefile
-index 58b2b0489fc9..c41c4c0f9264 100644
+index 58b2b04..c41c4c0 100644
 --- a/drivers/virtio/Makefile
 +++ b/drivers/virtio/Makefile
 @@ -14,3 +14,5 @@ obj-$(CONFIG_VIRTIO_VDPA) += virtio_vdpa.o
@@ -85,7 +85,7 @@ index 58b2b0489fc9..c41c4c0f9264 100644
 +virtio_rtc-y := virtio_rtc_driver.o
 diff --git a/drivers/virtio/virtio_rtc_driver.c b/drivers/virtio/virtio_rtc_driver.c
 new file mode 100644
-index 000000000000..c87ee4e63424
+index 0000000..c87ee4e
 --- /dev/null
 +++ b/drivers/virtio/virtio_rtc_driver.c
 @@ -0,0 +1,786 @@
@@ -877,7 +877,7 @@ index 000000000000..c87ee4e63424
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/virtio/virtio_rtc_internal.h b/drivers/virtio/virtio_rtc_internal.h
 new file mode 100644
-index 000000000000..9c249c15b68f
+index 0000000..9c249c1
 --- /dev/null
 +++ b/drivers/virtio/virtio_rtc_internal.h
 @@ -0,0 +1,24 @@
@@ -907,7 +907,7 @@ index 000000000000..9c249c15b68f
 +#endif /* _VIRTIO_RTC_INTERNAL_H_ */
 diff --git a/include/uapi/linux/virtio_rtc.h b/include/uapi/linux/virtio_rtc.h
 new file mode 100644
-index 000000000000..6b3af4e9bbfb
+index 0000000..6b3af4e
 --- /dev/null
 +++ b/include/uapi/linux/virtio_rtc.h
 @@ -0,0 +1,151 @@

--- a/patches/0027-virtio_rtc-Add-PTP-clocks.patch
+++ b/patches/0027-virtio_rtc-Add-PTP-clocks.patch
@@ -1,4 +1,4 @@
-From 6288d84bd2be25daba854cff0d2d8fbedab76b5b Mon Sep 17 00:00:00 2001
+From 220088ab93e86df6c9bb218341db9b1733d5350d Mon Sep 17 00:00:00 2001
 From: Peter Hilber <quic_philber@quicinc.com>
 Date: Fri, 9 May 2025 18:07:23 +0200
 Subject: [PATCH 27/30] virtio_rtc: Add PTP clocks
@@ -57,7 +57,7 @@ Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
  create mode 100644 drivers/virtio/virtio_rtc_ptp.c
 
 diff --git a/drivers/virtio/Kconfig b/drivers/virtio/Kconfig
-index fd6b826af19a..c98e43a1ee95 100644
+index fd6b826..c98e43a 100644
 --- a/drivers/virtio/Kconfig
 +++ b/drivers/virtio/Kconfig
 @@ -194,11 +194,33 @@ config VIRTIO_RTC
@@ -96,7 +96,7 @@ index fd6b826af19a..c98e43a1ee95 100644
 +
  endif # VIRTIO_MENU
 diff --git a/drivers/virtio/Makefile b/drivers/virtio/Makefile
-index c41c4c0f9264..88d6fb8d4731 100644
+index c41c4c0..88d6fb8 100644
 --- a/drivers/virtio/Makefile
 +++ b/drivers/virtio/Makefile
 @@ -16,3 +16,4 @@ obj-$(CONFIG_VIRTIO_DMA_SHARED_BUFFER) += virtio_dma_buf.o
@@ -105,7 +105,7 @@ index c41c4c0f9264..88d6fb8d4731 100644
  virtio_rtc-y := virtio_rtc_driver.o
 +virtio_rtc-$(CONFIG_VIRTIO_RTC_PTP) += virtio_rtc_ptp.o
 diff --git a/drivers/virtio/virtio_rtc_driver.c b/drivers/virtio/virtio_rtc_driver.c
-index c87ee4e63424..7499908ee34c 100644
+index c87ee4e..7499908 100644
 --- a/drivers/virtio/virtio_rtc_driver.c
 +++ b/drivers/virtio/virtio_rtc_driver.c
 @@ -38,11 +38,16 @@ struct viortc_vq {
@@ -270,7 +270,7 @@ index c87ee4e63424..7499908ee34c 100644
  	virtio_reset_device(vdev);
  	vdev->config->del_vqs(vdev);
 diff --git a/drivers/virtio/virtio_rtc_internal.h b/drivers/virtio/virtio_rtc_internal.h
-index 9c249c15b68f..2e589903d04f 100644
+index 9c249c1..2e58990 100644
 --- a/drivers/virtio/virtio_rtc_internal.h
 +++ b/drivers/virtio/virtio_rtc_internal.h
 @@ -9,6 +9,7 @@
@@ -333,7 +333,7 @@ index 9c249c15b68f..2e589903d04f 100644
  #endif /* _VIRTIO_RTC_INTERNAL_H_ */
 diff --git a/drivers/virtio/virtio_rtc_ptp.c b/drivers/virtio/virtio_rtc_ptp.c
 new file mode 100644
-index 000000000000..f84599950cd4
+index 0000000..f845999
 --- /dev/null
 +++ b/drivers/virtio/virtio_rtc_ptp.c
 @@ -0,0 +1,347 @@

--- a/patches/0028-virtio_rtc-Add-Arm-Generic-Timer-cross-timestamping.patch
+++ b/patches/0028-virtio_rtc-Add-Arm-Generic-Timer-cross-timestamping.patch
@@ -1,4 +1,4 @@
-From 874ed6f7613d8b57ddeb5cc53a5e04e3d29cf25c Mon Sep 17 00:00:00 2001
+From 11eac475e248510ed81a76814a384a2976a0853b Mon Sep 17 00:00:00 2001
 From: Peter Hilber <quic_philber@quicinc.com>
 Date: Fri, 9 May 2025 18:07:24 +0200
 Subject: [PATCH 28/30] virtio_rtc: Add Arm Generic Timer cross-timestamping
@@ -21,7 +21,7 @@ Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
  create mode 100644 drivers/virtio/virtio_rtc_arm.c
 
 diff --git a/drivers/virtio/Kconfig b/drivers/virtio/Kconfig
-index c98e43a1ee95..57beef80dcc5 100644
+index c98e43a..57beef8 100644
 --- a/drivers/virtio/Kconfig
 +++ b/drivers/virtio/Kconfig
 @@ -221,6 +221,19 @@ config VIRTIO_RTC_PTP
@@ -45,7 +45,7 @@ index c98e43a1ee95..57beef80dcc5 100644
  
  endif # VIRTIO_MENU
 diff --git a/drivers/virtio/Makefile b/drivers/virtio/Makefile
-index 88d6fb8d4731..dbd77f124ba9 100644
+index 88d6fb8..dbd77f1 100644
 --- a/drivers/virtio/Makefile
 +++ b/drivers/virtio/Makefile
 @@ -17,3 +17,4 @@ obj-$(CONFIG_VIRTIO_DEBUG) += virtio_debug.o
@@ -55,7 +55,7 @@ index 88d6fb8d4731..dbd77f124ba9 100644
 +virtio_rtc-$(CONFIG_VIRTIO_RTC_ARM) += virtio_rtc_arm.o
 diff --git a/drivers/virtio/virtio_rtc_arm.c b/drivers/virtio/virtio_rtc_arm.c
 new file mode 100644
-index 000000000000..211299d72870
+index 0000000..211299d
 --- /dev/null
 +++ b/drivers/virtio/virtio_rtc_arm.c
 @@ -0,0 +1,23 @@

--- a/patches/0029-virtio_rtc-Add-RTC-class-driver.patch
+++ b/patches/0029-virtio_rtc-Add-RTC-class-driver.patch
@@ -1,4 +1,4 @@
-From 12d2d822791bdd3a87e717221c488f5f38ccd102 Mon Sep 17 00:00:00 2001
+From e475b0cbac850cac368e873b58c86112a67e0014 Mon Sep 17 00:00:00 2001
 From: Peter Hilber <quic_philber@quicinc.com>
 Date: Fri, 9 May 2025 18:07:25 +0200
 Subject: [PATCH 29/30] virtio_rtc: Add RTC class driver
@@ -55,7 +55,7 @@ Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
  create mode 100644 drivers/virtio/virtio_rtc_class.c
 
 diff --git a/drivers/virtio/Kconfig b/drivers/virtio/Kconfig
-index 57beef80dcc5..8279d6d5a1f1 100644
+index 57beef8..8279d6d 100644
 --- a/drivers/virtio/Kconfig
 +++ b/drivers/virtio/Kconfig
 @@ -195,7 +195,8 @@ config VIRTIO_RTC
@@ -102,7 +102,7 @@ index 57beef80dcc5..8279d6d5a1f1 100644
  
  endif # VIRTIO_MENU
 diff --git a/drivers/virtio/Makefile b/drivers/virtio/Makefile
-index dbd77f124ba9..eefcfe90d6b8 100644
+index dbd77f1..eefcfe9 100644
 --- a/drivers/virtio/Makefile
 +++ b/drivers/virtio/Makefile
 @@ -18,3 +18,4 @@ obj-$(CONFIG_VIRTIO_RTC) += virtio_rtc.o
@@ -112,7 +112,7 @@ index dbd77f124ba9..eefcfe90d6b8 100644
 +virtio_rtc-$(CONFIG_VIRTIO_RTC_CLASS) += virtio_rtc_class.o
 diff --git a/drivers/virtio/virtio_rtc_class.c b/drivers/virtio/virtio_rtc_class.c
 new file mode 100644
-index 000000000000..05d6d28255cf
+index 0000000..05d6d28
 --- /dev/null
 +++ b/drivers/virtio/virtio_rtc_class.c
 @@ -0,0 +1,262 @@
@@ -379,7 +379,7 @@ index 000000000000..05d6d28255cf
 +	return viortc_class;
 +}
 diff --git a/drivers/virtio/virtio_rtc_driver.c b/drivers/virtio/virtio_rtc_driver.c
-index 7499908ee34c..a57d5e06e19d 100644
+index 7499908..a57d5e0 100644
 --- a/drivers/virtio/virtio_rtc_driver.c
 +++ b/drivers/virtio/virtio_rtc_driver.c
 @@ -18,9 +18,12 @@
@@ -1068,7 +1068,7 @@ index 7499908ee34c..a57d5e06e19d 100644
  	.probe = viortc_probe,
  	.remove = viortc_remove,
 diff --git a/drivers/virtio/virtio_rtc_internal.h b/drivers/virtio/virtio_rtc_internal.h
-index 2e589903d04f..296afee6719b 100644
+index 2e58990..296afee 100644
 --- a/drivers/virtio/virtio_rtc_internal.h
 +++ b/drivers/virtio/virtio_rtc_internal.h
 @@ -9,6 +9,8 @@
@@ -1143,7 +1143,7 @@ index 2e589903d04f..296afee6719b 100644
 +
  #endif /* _VIRTIO_RTC_INTERNAL_H_ */
 diff --git a/include/uapi/linux/virtio_rtc.h b/include/uapi/linux/virtio_rtc.h
-index 6b3af4e9bbfb..85ee8f013661 100644
+index 6b3af4e..85ee8f0 100644
 --- a/include/uapi/linux/virtio_rtc.h
 +++ b/include/uapi/linux/virtio_rtc.h
 @@ -9,6 +9,9 @@

--- a/patches/0030-virtio_rtc-Fix-compatibility-for-kernel-6.12.patch
+++ b/patches/0030-virtio_rtc-Fix-compatibility-for-kernel-6.12.patch
@@ -1,4 +1,4 @@
-From 39efc8beac63269f7f0dc556fcca095ffd1415bb Mon Sep 17 00:00:00 2001
+From 2a3cd029a496a2142f78b6ce9b0a04dc09ea3150 Mon Sep 17 00:00:00 2001
 From: Dorinda Bassey <dbassey@redhat.com>
 Date: Wed, 29 Apr 2026 11:35:00 +0200
 Subject: [PATCH 30/30] virtio_rtc: Fix compatibility for kernel 6.12
@@ -17,7 +17,7 @@ Signed-off-by: Dorinda Bassey <dbassey@redhat.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/virtio/virtio_rtc_driver.c b/drivers/virtio/virtio_rtc_driver.c
-index a57d5e06e19d..bc303c32dab3 100644
+index a57d5e0..bc303c3 100644
 --- a/drivers/virtio/virtio_rtc_driver.c
 +++ b/drivers/virtio/virtio_rtc_driver.c
 @@ -575,7 +575,7 @@ static int viortc_msg_xfer(struct viortc_vq *vq, struct viortc_msg *msg,


### PR DESCRIPTION
Add protocol to struct tsi_proxy_create and struct tsi_sock so the  host VMM can distinguish `SOCK_DGRAM`+`IPPROTO_ICMP` ("ping" socket) from plain UDP. Without this, TSI hijacks ping sockets but the host creates UDP sockets, breaking ICMP echo.

This enables ping for implementations that use SOCK_DGRAM ping sockets (iputils on modern Fedora, Ubuntu, etc.). SOCK_RAW-based ping (busybox/alpine) is not supported as TSI only hijacks SOCK_STREAM and SOCK_DGRAM.

Forward SO_RCVTIMEO/SO_SNDTIMEO to both isocket and vsocket in `tsi_dgram_setsockopt`.  SOCK_CUSTOM_SOCKOPT routes SOL_SOCKET options through TSI's handler which only applied them to isocket, but after the S_HYBRID -> S_VSOCK transition recvmsg goes through vsocket. Without this, iputils ping -6 -c 2 hangs after the first reply because the vsock recvmsg blocks forever.

Coresponding libkrun side fix + test: containers/libkrun#690

Assisted-by: OpenCode:claude-opus-4.6