### PR TITLE
Add some basic pkg dependency docs for building on Debian/Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ KRUNFW_SONAME_Windows = libkrunfw.dll
 KRUNFW_BASE_Windows = libkrunfw.dll
 SONAME_Windows =
 
-LIBDIR_Linux = lib64
+LIBDIR_Linux = $(shell if [ -e /etc/debian_version ]; then echo 'lib/$(HOSTARCH)-linux-gnu'; else echo lib64; fi)
 LIBDIR_Darwin = lib
 LIBDIR_Windows = bin
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ By having the kernel bundled in a dynamic library, ```libkrun``` can leave to th
 #### Requirements
 * The toolchain your distribution needs to build a Linux kernel.
 * Python 3
-* ```pyelftools``` (package ```python3-pyelftools``` in Fedora and Ubuntu)
+* ```pyelftools``` (package ```python3-pyelftools``` in Fedora)
+
+On Debian/Ubuntu:
+
+```sh
+apt install python3-pyelftools build-essential flex bison libelf-dev
+```
 
 #### Building and installing the library
 ```


### PR DESCRIPTION
Add some brief docs for build time dependencies on Debian/Ubuntu machines.

Also adjust the output directory to match something closer to their usual paths.

Assisted-by: Codex:GPT-5